### PR TITLE
another small patch - prevent duplicate consecutive lines

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -557,6 +557,12 @@ int linenoiseHistoryAdd(const char *line) {
         if (history == NULL) return 0;
         memset(history,0,(sizeof(char*)*history_max_len));
     }
+    //do not insert duplicate lines into history
+    
+    if (history_len > 0 && !strcmp(line, history[history_len - 1])) {
+		return 0;
+	}
+	
     linecopy = strdup(line);
     if (!linecopy) return 0;
     if (history_len == history_max_len) {


### PR DESCRIPTION
this is a matter of taste I suppose, but I like the way bash handles this, if I run the same query over and over again, this patch makes sure it is not added to the history more than once (for consecutive commands only, of course).
this is useful if you are running a bunch of queries to test some ongoing process.
