### PR TITLE
fix getColumns() for Buildroot

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,6 +32,7 @@ The library is currently less than 400 lines of code. In order to use it in your
  * Linux text only console ($TERM = linux)
  * Linux KDE terminal application ($TERM = xterm)
  * Linux xterm ($TERM = xterm)
+ * Linux Buildroot ($TERM = vt100)
  * Mac OS X iTerm ($TERM = xterm)
  * Mac OS X default Terminal.app ($TERM = xterm)
  * OpenBSD 4.5 through an OSX Terminal.app ($TERM = screen)

--- a/linenoise.c
+++ b/linenoise.c
@@ -182,7 +182,7 @@ static void linenoiseAtExit(void) {
 static int getColumns(void) {
     struct winsize ws;
 
-    if (ioctl(1, TIOCGWINSZ, &ws) == -1) return 80;
+    if (ioctl(1, TIOCGWINSZ, &ws) == -1 || ws.ws_col == 0) return 80;
     return ws.ws_col;
 }
 


### PR DESCRIPTION
Hi,

a small patch for Buildroot which is  cross-compiling environment for embedded linux (see
http://buildroot.uclibc.org/).
