### PR TITLE
Add missing function prototypes.

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -139,6 +139,13 @@ struct linenoiseState {
 static void linenoiseAtExit(void);
 int linenoiseHistoryAdd(const char *line);
 static void refreshLine(struct linenoiseState *l);
+int linenoiseEditInsert(struct linenoiseState *l, int c);
+void linenoiseEditMoveLeft(struct linenoiseState *l);
+void linenoiseEditMoveRight(struct linenoiseState *l);
+void linenoiseEditHistoryNext(struct linenoiseState *l, int dir);
+void linenoiseEditDelete(struct linenoiseState *l);
+void linenoiseEditBackspace(struct linenoiseState *l);
+void linenoiseEditDeletePrevWord(struct linenoiseState *l);
 
 /* ======================= Low level terminal handling ====================== */
 


### PR DESCRIPTION
Useful to avoid warnings when you compile with `-Wmissing-prototypes`.
