### PR TITLE
Add "emacs" to unsupported_term

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -108,7 +108,7 @@
 
 #define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
 #define LINENOISE_MAX_LINE 4096
-static char *unsupported_term[] = {"dumb","cons25",NULL};
+static char *unsupported_term[] = {"dumb","cons25","emacs",NULL};
 static linenoiseCompletionCallback *completionCallback = NULL;
 
 static struct termios orig_termios; /* In order to restore at exit.*/


### PR DESCRIPTION
The Emacs terminal emulator has its own line editing and does not
behave correctly in raw mode. Without this programs using linenoise
will hang when run inside an Emacs shell.
