### PR TITLE
fix linenoiseEdit buflen decreasing.

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -593,8 +593,8 @@ static int linenoiseEdit(int fd, char *buf, size_t buflen, const char *prompt)
     l.history_index = 0;
 
     /* Buffer starts empty. */
-    buf[0] = '\0';
-    buflen--; /* Make sure there is always space for the nulterm */
+    l.buf[0] = '\0';
+    l.buflen--; /* Make sure there is always space for the nulterm */
 
     /* The latest history entry is always our current buffer, that
      * initially is just an empty string. */


### PR DESCRIPTION
Hi.

I think there is a bug when you keep room for trailing zero. Can you confirm this please ?

Regards.
