### PR TITLE
Allow tab-completion only at the end of line and replace magic number

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -745,7 +745,7 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
         /* Only autocomplete when the callback is set. It returns < 0 when
          * there was an error reading from fd. Otherwise it will return the
          * character that should be handled next. */
-        if (c == '\t' && completionCallback != NULL) {
+        if (c == '\t' && l.pos == l.len && completionCallback != NULL) {
             c = completeLine(&l);
             /* Return on errors */
             if (c < 0) return l.len;


### PR DESCRIPTION
Currently tab-completion may take place at arbitrary cursor positions, but there is no way to figure out the cursor position from within the line completion code, effectively preventing sensible completion at that place. Hence I limited tab-completion to the end of line, to prevent user confusion.

I also replaced the magic 9 in that line with '\t'.

A similar patch was merged to msteveb's repository as msteveb/linenoise#2
