### PR TITLE
One liners for minor cleanup

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -2,7 +2,7 @@
  * line editing lib needs to be 20,000 lines of C code.
  *
  * You can find the latest source code at:
- * 
+ *
  *   http://github.com/antirez/linenoise
  *
  * Does a number of crazy assumptions that happen to be true in 99.9999% of
@@ -14,18 +14,18 @@
  * Copyright (c) 2010-2013, Pieter Noordhuis <pcnoordhuis at gmail dot com>
  *
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
- * 
+ *
  *  *  Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *
  *  *  Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -37,7 +37,7 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * ------------------------------------------------------------------------
  *
  * References:
@@ -91,7 +91,7 @@
  * ED2 (Clear entire screen)
  *    Sequence: ESC [ 2 J
  *    Effect: clear the whole screen
- * 
+ *
  */
 
 #define _XOPEN_SOURCE 500       /* strdup */
@@ -142,25 +142,25 @@ struct linenoiseState {
 };
 
 enum KEY_ACTION{
-	KEY_NULL = 0,	    /* NULL */
-	CTRL_A = 1,         /* Ctrl+a */
-	CTRL_B = 2,         /* Ctrl-b */
-	CTRL_C = 3,         /* Ctrl-c */
-	CTRL_D = 4,         /* Ctrl-d */
-	CTRL_E = 5,         /* Ctrl-e */
-	CTRL_F = 6,         /* Ctrl-f */
-	CTRL_H = 8,         /* Ctrl-h */
-	TAB = 9,            /* Tab */
-	CTRL_K = 11,        /* Ctrl+k */
-	CTRL_L = 12,        /* Ctrl+l */
-	ENTER = 13,         /* Enter */
-	CTRL_N = 14,        /* Ctrl-n */
-	CTRL_P = 16,        /* Ctrl-p */
-	CTRL_T = 20,        /* Ctrl-t */
-	CTRL_U = 21,        /* Ctrl+u */
-	CTRL_W = 23,        /* Ctrl+w */
-	ESC = 27,           /* Escape */
-	BACKSPACE =  127    /* Backspace */
+       KEY_NULL = 0,       /* NULL */
+       CTRL_A = 1,         /* Ctrl+a */
+       CTRL_B = 2,         /* Ctrl-b */
+       CTRL_C = 3,         /* Ctrl-c */
+       CTRL_D = 4,         /* Ctrl-d */
+       CTRL_E = 5,         /* Ctrl-e */
+       CTRL_F = 6,         /* Ctrl-f */
+       CTRL_H = 8,         /* Ctrl-h */
+       TAB = 9,            /* Tab */
+       CTRL_K = 11,        /* Ctrl+k */
+       CTRL_L = 12,        /* Ctrl+l */
+       ENTER = 13,         /* Enter */
+       CTRL_N = 14,        /* Ctrl-n */
+       CTRL_P = 16,        /* Ctrl-p */
+       CTRL_T = 20,        /* Ctrl-t */
+       CTRL_U = 21,        /* Ctrl+u */
+       CTRL_W = 23,        /* Ctrl+w */
+       ESC = 27,           /* Escape */
+       BACKSPACE =  127    /* Backspace */
 };
 
 static void linenoiseAtExit(void);
@@ -335,7 +335,7 @@ static void freeCompletions(linenoiseCompletions *lc) {
 /* This is an helper function for linenoiseEdit() and is called when the
  * user types the <tab> key in order to complete the string currently in the
  * input.
- * 
+ *
  * The state of the editing is encapsulated into the pointed linenoiseState
  * structure as described in the structure definition. */
 static int completeLine(struct linenoiseState *ls) {
@@ -462,7 +462,7 @@ static void refreshSingleLine(struct linenoiseState *l) {
     size_t len = l->len;
     size_t pos = l->pos;
     struct abuf ab;
-    
+
     while((plen+pos) >= l->cols) {
         buf++;
         len--;
@@ -526,7 +526,7 @@ static void refreshMultiLine(struct linenoiseState *l) {
     lndebug("%s", "clear");
     snprintf(seq,64,"\x1b[0G\x1b[0K");
     abAppend(&ab,seq,strlen(seq));
-    
+
     /* Write the prompt and the current buffer content */
     abAppend(&ab,l->prompt,strlen(l->prompt));
     abAppend(&ab,l->buf,l->len);
@@ -710,7 +710,11 @@ void linenoiseEditDeletePrevWord(struct linenoiseState *l) {
  * when ctrl+d is typed.
  *
  * The function returns the length of the current buffer. */
-static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, const char *prompt)
+static int linenoiseEdit(int stdin_fd,
+                         int stdout_fd,
+                         char *buf,
+                         size_t buflen,
+                         const char *prompt)
 {
     struct linenoiseState l;
 
@@ -735,7 +739,7 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
     /* The latest history entry is always our current buffer, that
      * initially is just an empty string. */
     linenoiseHistoryAdd("");
-    
+
     if (write(l.ofd,prompt,l.plen) == -1) return -1;
     while(1) {
         char c;
@@ -1061,7 +1065,7 @@ int linenoiseHistorySetMaxLen(int len) {
 int linenoiseHistorySave(const char *filename) {
     FILE *fp = fopen(filename,"w");
     int j;
-    
+
     if (fp == NULL) return -1;
     for (j = 0; j < history_len; j++)
         fprintf(fp,"%s\n",history[j]);
@@ -1077,12 +1081,12 @@ int linenoiseHistorySave(const char *filename) {
 int linenoiseHistoryLoad(const char *filename) {
     FILE *fp = fopen(filename,"r");
     char buf[LINENOISE_MAX_LINE];
-    
+
     if (fp == NULL) return -1;
 
     while (fgets(buf,LINENOISE_MAX_LINE,fp) != NULL) {
         char *p;
-        
+
         p = strchr(buf,'\r');
         if (!p) p = strchr(buf,'\n');
         if (p) *p = '\0';

--- a/linenoise.c
+++ b/linenoise.c
@@ -340,7 +340,6 @@ static void freeCompletions(linenoiseCompletions *lc) {
  * structure as described in the structure definition. */
 static int completeLine(struct linenoiseState *ls) {
     linenoiseCompletions lc = { 0, NULL };
-    int nread, nwritten;
     char c = 0;
 
     completionCallback(ls->buf,&lc);
@@ -348,6 +347,7 @@ static int completeLine(struct linenoiseState *ls) {
         linenoiseBeep();
     } else {
         size_t stop = 0, i = 0;
+        int nread, nwritten;
 
         while(!stop) {
             /* Show completion or original buffer */

--- a/linenoise.c
+++ b/linenoise.c
@@ -268,7 +268,7 @@ static int getCursorPosition(int ifd, int ofd) {
 
     /* Parse it. */
     if (buf[0] != ESC || buf[1] != '[') return -1;
-    if (sscanf(buf+2,"%d;%d",&rows,&cols) != 2) return -1;
+    if (sscanf(buf+2,"%6d;%6d",&rows,&cols) != 2) return -1;
     return cols;
 }
 

--- a/linenoise.c
+++ b/linenoise.c
@@ -94,12 +94,15 @@
  * 
  */
 
+#define _XOPEN_SOURCE 500       /* strdup */
+
 #include <termios.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <sys/types.h>

--- a/linenoise.c
+++ b/linenoise.c
@@ -348,11 +348,12 @@ static int completeLine(struct linenoiseState *ls) {
     } else {
         size_t stop = 0, i = 0;
         int nread, nwritten;
+        struct linenoiseState saved;
 
         while(!stop) {
             /* Show completion or original buffer */
             if (i < lc.len) {
-                struct linenoiseState saved = *ls;
+                saved = *ls;
 
                 ls->len = ls->pos = strlen(lc.cvec[i]);
                 ls->buf = lc.cvec[i];

--- a/linenoise.c
+++ b/linenoise.c
@@ -952,7 +952,6 @@ static int linenoiseRaw(char *buf, size_t buflen, const char *prompt) {
  * something even in the most desperate of the conditions. */
 char *linenoise(const char *prompt) {
     char buf[LINENOISE_MAX_LINE];
-    int count;
 
     if (isUnsupportedTerm()) {
         size_t len;
@@ -967,6 +966,8 @@ char *linenoise(const char *prompt) {
         }
         return strdup(buf);
     } else {
+        int count;
+
         count = linenoiseRaw(buf,LINENOISE_MAX_LINE,prompt);
         if (count == -1) return NULL;
         return strdup(buf);

--- a/linenoise.c
+++ b/linenoise.c
@@ -517,13 +517,13 @@ static void refreshMultiLine(struct linenoiseState *l) {
 
     /* Now for every row clear it, go up. */
     for (j = 0; j < old_rows-1; j++) {
-        lndebug("clear+up");
+        lndebug("%s", "clear+up");
         snprintf(seq,64,"\x1b[0G\x1b[0K\x1b[1A");
         abAppend(&ab,seq,strlen(seq));
     }
 
     /* Clean the top line. */
-    lndebug("clear");
+    lndebug("%s", "clear");
     snprintf(seq,64,"\x1b[0G\x1b[0K");
     abAppend(&ab,seq,strlen(seq));
     
@@ -537,7 +537,7 @@ static void refreshMultiLine(struct linenoiseState *l) {
         l->pos == l->len &&
         (l->pos+plen) % l->cols == 0)
     {
-        lndebug("<newline>");
+        lndebug("%s", "<newline>");
         abAppend(&ab,"\n",1);
         snprintf(seq,64,"\x1b[0G");
         abAppend(&ab,seq,strlen(seq));
@@ -561,7 +561,7 @@ static void refreshMultiLine(struct linenoiseState *l) {
     snprintf(seq,64,"\x1b[%dG", 1+((plen+(int)l->pos) % (int)l->cols));
     abAppend(&ab,seq,strlen(seq));
 
-    lndebug("\n");
+    lndebug("%s", "\n");
     l->oldpos = l->pos;
 
     if (write(fd,ab.b,ab.len) == -1) {} /* Can't recover from write error. */


### PR DESCRIPTION
I am using linenoise in a project of mine, so this set of commits fixes the following:

1. Compile warnings with gcc -Wall -Wextra -pedantic -std=c11
2. CPPCheck warnings. There are a couple of those I didn't fix in this set of commits that have to do with memset and memcpy.
3. Whitespace cleanup :)