### PR TITLE
Helper function to add history entries as tab completions

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -418,6 +418,19 @@ void linenoiseAddCompletion(linenoiseCompletions *lc, const char *str) {
     lc->cvec[lc->len++] = copy;
 }
 
+/* Adds matching history entries as tab completions */
+void linenoiseAddHistoryCompletions(const char* buf, linenoiseCompletions *lc) {
+    int i;
+    size_t n;
+    if (history == NULL)
+        return;
+    n = strlen(buf);
+    for (i = 0; i < history_len; ++i)
+        if (strncasecmp(history[i], buf, n) == 0)
+            linenoiseAddCompletion(lc, history[i]);
+}
+
+
 /* =========================== Line editing ================================= */
 
 /* We define a very simple "append buffer" structure, that is an heap

--- a/linenoise.h
+++ b/linenoise.h
@@ -49,6 +49,7 @@ typedef struct linenoiseCompletions {
 typedef void(linenoiseCompletionCallback)(const char *, linenoiseCompletions *);
 void linenoiseSetCompletionCallback(linenoiseCompletionCallback *);
 void linenoiseAddCompletion(linenoiseCompletions *, const char *);
+void linenoiseAddHistoryCompletions(const char*, linenoiseCompletions *);
 
 char *linenoise(const char *prompt);
 int linenoiseHistoryAdd(const char *line);


### PR DESCRIPTION
Adds function which makes it easy to add the history as
tab completions.

Usage example:

void completion(const char\* buf, linenoiseCompletions\* lc) {
    linenoiseAddHistoryCompletions(buf, lc);
}
