### PR TITLE
Include stddef.h for size_t

### DIFF
--- a/linenoise.h
+++ b/linenoise.h
@@ -9,18 +9,18 @@
  * Copyright (c) 2010, Pieter Noordhuis <pcnoordhuis at gmail dot com>
  *
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
- * 
+ *
  *  *  Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
  *
  *  *  Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -41,6 +41,7 @@
 extern "C" {
 #endif
 
+#include <stddef.h>
 typedef struct linenoiseCompletions {
   size_t len;
   char **cvec;


### PR DESCRIPTION
 Headers should compile as if they were source code too. Without including stddef.h, linenoise.h cannot be included without first including something that exposes size_t. stddef.h is the least invasive way of doing this, other headers like stdio.h and string.h; while they may expose size_t are more invasive. This patch also fixes trailing whitespace in the license header as well.
