### PR TITLE
Fix compiler warnings when in C99 standards mode

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -100,6 +100,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <sys/types.h>
@@ -182,6 +183,16 @@ FILE *lndebug_fp = NULL;
 #else
 #define lndebug(fmt, ...)
 #endif
+
+/* String routines. */
+static char *strclone(const char *str) {
+    size_t size = strlen(str) + 1;
+    char *copy = malloc(size);
+    if (copy == NULL) return NULL;
+
+    memcpy(copy, str, size);
+    return copy;
+}
 
 /* ======================= Low level terminal handling ====================== */
 
@@ -644,7 +655,7 @@ void linenoiseEditHistoryNext(struct linenoiseState *l, int dir) {
         /* Update the current history entry before to
          * overwrite it with the next one. */
         free(history[history_len - 1 - l->history_index]);
-        history[history_len - 1 - l->history_index] = strdup(l->buf);
+        history[history_len - 1 - l->history_index] = strclone(l->buf);
         /* Show the new entry */
         l->history_index += (dir == LINENOISE_HISTORY_PREV) ? 1 : -1;
         if (l->history_index < 0) {
@@ -957,11 +968,11 @@ char *linenoise(const char *prompt) {
             len--;
             buf[len] = '\0';
         }
-        return strdup(buf);
+        return strclone(buf);
     } else {
         count = linenoiseRaw(buf,LINENOISE_MAX_LINE,prompt);
         if (count == -1) return NULL;
-        return strdup(buf);
+        return strclone(buf);
     }
 }
 
@@ -1009,7 +1020,7 @@ int linenoiseHistoryAdd(const char *line) {
 
     /* Add an heap allocated copy of the line in the history.
      * If we reached the max length, remove the older line. */
-    linecopy = strdup(line);
+    linecopy = strclone(line);
     if (!linecopy) return 0;
     if (history_len == history_max_len) {
         free(history[0]);


### PR DESCRIPTION
Output when compiling (with `clang -Wall -std=c99`):

```
src/linenoise.c:201:14: warning: implicit declaration of function 'strcasecmp' is invalid
      in C99 [-Wimplicit-function-declaration]
        if (!strcasecmp(term,unsupported_term[j])) return 1;
             ^
src/linenoise.c:647:55: warning: implicitly declaring C library function 'strdup' with
      type 'char *(const char *)'
        history[history_len - 1 - l->history_index] = strdup(l->buf);
                                                      ^
src/linenoise.c:647:55: note: please include the header <string.h> or explicitly provide a
      declaration for 'strdup'
```

`strcasecmp` just required a include of `strings.h`, but it turns out `strdup` isn't standard C - [it's a POSIX thing](http://stackoverflow.com/a/252802/716118).
