### PR TITLE
make linenoiseEdit read resilient to signal

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -742,7 +742,7 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
 	/* Continue reading if interrupted by a signal */
 	do {
           nread = read(l.ifd,&c,1);
-        } while((nread <= 0) && (errno == EINTR));
+        } while((nread == -1) && (errno == EINTR));
 
         if (nread <= 0) return l.len;
         


### PR DESCRIPTION
Read in a loop and allow retry if read was interrupted by a signal.

Rationale : 
I use linenoise in a piece of code that uses posix timers (bound to realtime signal). Every time the timer fires,
read returns -1 and errno is set to EINTR. This causes linenoise to think that an empty line was read, and this closes my interactive session.
This patch prevents this from happening : a signal just causes read to retry.
