### PR TITLE
Remove disabling post-processing when setting rawmode

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -916,7 +916,7 @@ void linenoisePrintKeyCodes(void) {
         if (memcmp(quit,"quit",sizeof(quit)) == 0) break;
 
         printf("'%c' %02x (%d) (type quit to exit)\n",
-            isprint(c) ? c : '?', (int)c, (int)c);
+            isprint((int)c) ? c : '?', (int)c, (int)c);
         printf("\r"); /* Go left edge manually, we are in raw mode. */
         fflush(stdout);
     }


### PR DESCRIPTION
Not exactly sure why this was here in the first place. Keeping it breaks newlines in msys/cygwin, removing it fixes them and should still work without issue on proper *NIX systems. With the removal, linenoise should work fine on win32 with msys/cygwin.
