### PR TITLE
Add linenoiseHistoryGet() to access to history. Fix redundant declaratio...

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -170,7 +170,6 @@ enum KEY_ACTION{
 };
 
 static void linenoiseAtExit(void);
-int linenoiseHistoryAdd(const char *line);
 static void refreshLine(struct linenoiseState *l);
 
 /* Debugging macro. */
@@ -1102,4 +1101,13 @@ int linenoiseHistoryLoad(const char *filename) {
     }
     fclose(fp);
     return 0;
+}
+
+/* Provide access to history. */
+int linenoiseHistoryGet(char ***_history, int *_history_len) {
+  if (_history)
+    *_history = history;
+  if (_history_len)
+    *_history_len = history_len;
+  return 0;
 }


### PR DESCRIPTION
...n

I added API to access history to be able to replicate C-shell history functionality in my project.
