### PR TITLE
add line-feed as ENTER key

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -157,6 +157,7 @@ enum KEY_ACTION{
 	CTRL_F = 6,         /* Ctrl-f */
 	CTRL_H = 8,         /* Ctrl-h */
 	TAB = 9,            /* Tab */
+	LINE_FEED = 10,     /* Line Feed */
 	CTRL_K = 11,        /* Ctrl+k */
 	CTRL_L = 12,        /* Ctrl+l */
 	ENTER = 13,         /* Enter */
@@ -768,6 +769,7 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
         }
 
         switch(c) {
+        case LINE_FEED:/* line feed */
         case ENTER:    /* enter */
             history_len--;
             free(history[history_len]);


### PR DESCRIPTION
In Android's adb shell environment test, click ENTER get line-feed.