### PR TITLE
vi bindings

### DIFF
--- a/example.c
+++ b/example.c
@@ -14,6 +14,8 @@ void completion(const char *buf, linenoiseCompletions *lc) {
 int main(int argc, char **argv) {
     char *line;
     char *prgname = argv[0];
+    char *(*run)(const char *);
+    int vimode = 0;
 
     /* Parse options, with --multiline we enable multi line editing. */
     while(argc > 1) {
@@ -25,6 +27,8 @@ int main(int argc, char **argv) {
         } else if (!strcmp(*argv,"--keycodes")) {
             linenoisePrintKeyCodes();
             exit(0);
+	} else if (!strcmp(*argv, "-v")) {
+            vimode = 1;
         } else {
             fprintf(stderr, "Usage: %s [--multiline] [--keycodes]\n", prgname);
             exit(1);
@@ -45,7 +49,14 @@ int main(int argc, char **argv) {
      *
      * The typed string is returned as a malloc() allocated string by
      * linenoise, so the user needs to free() it. */
-    while((line = linenoise("hello> ")) != NULL) {
+
+    if (vimode == 1) {
+        run = &linenoisevi;
+    } else {
+        run = &linenoise;
+    }
+
+    while((line = run("hello> ")) != NULL) {
         /* Do something with the string. */
         if (line[0] != '\0' && line[0] != '/') {
             printf("echo: '%s'\n", line);

--- a/linenoise.c
+++ b/linenoise.c
@@ -130,6 +130,8 @@ static int atexit_registered = 0; /* Register atexit just 1 time. */
 static int history_max_len = LINENOISE_DEFAULT_HISTORY_MAX_LEN;
 static int history_len = 0;
 static char **history = NULL;
+static int vimode = 0;
+static int viesc = 0;
 
 /* The linenoiseState structure represents the state during line editing.
  * We pass this state to functions implementing specific editing
@@ -651,6 +653,29 @@ void linenoiseEditMoveEnd(struct linenoiseState *l) {
     }
 }
 
+/* Move the cursor to the beginning of the previous word. If
+ * no previous word exists, move the cursor to the beginning
+ * of the line */
+void linenoiseEditMovePrevWord(struct linenoiseState *l) {
+    while (l->pos > 0 && l->buf[l->pos-1] == ' ')
+        l->pos--;
+    while (l->pos > 0 && l->buf[l->pos-1] != ' ')
+        l->pos--;
+    refreshLine(l);
+}
+
+/* Move the cursor to the beginning of the next word. If
+ * no next word exists, move cursor to the end of the line */
+void linenoiseEditMoveNextWord(struct linenoiseState *l) {
+    while (l->pos < l->len && l->buf[l->pos+1] != ' ')
+        l->pos++;
+    while (l->pos < l->len && l->buf[l->pos+1] == ' ')
+        l->pos++;
+    if (l->pos < l->len)
+        l->pos++;
+    refreshLine(l);
+}
+
 /* Substitute the currently edited line with the next or previous history
  * entry as specified by 'dir'. */
 #define LINENOISE_HISTORY_NEXT 0
@@ -699,7 +724,7 @@ void linenoiseEditBackspace(struct linenoiseState *l) {
     }
 }
 
-/* Delete the previosu word, maintaining the cursor at the start of the
+/* Delete the previous word, maintaining the cursor at the start of the
  * current word. */
 void linenoiseEditDeletePrevWord(struct linenoiseState *l) {
     size_t old_pos = l->pos;
@@ -712,6 +737,23 @@ void linenoiseEditDeletePrevWord(struct linenoiseState *l) {
     diff = old_pos - l->pos;
     memmove(l->buf+l->pos,l->buf+old_pos,l->len-old_pos+1);
     l->len -= diff;
+    refreshLine(l);
+}
+
+/* Delete the next word, maintaining the cursor at the start of the
+ * current word. */
+void linenoiseEditDeleteNextWord(struct linenoiseState *l) {
+    size_t old_pos = l->pos;
+    size_t diff;
+
+    while (l->pos < l->len && l->buf[l->pos+1] == ' ')
+        l->pos++;
+    while (l->pos < l->len && l->buf[l->pos+1] != ' ')
+        l->pos++;
+    diff = l->pos - old_pos;
+    memmove(l->buf+old_pos, l->buf+l->pos+1,l->len-l->pos+1);
+    l->len -= diff;
+    l->pos = old_pos;
     refreshLine(l);
 }
 
@@ -769,83 +811,188 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
             if (c == 0) continue;
         }
 
-        switch(c) {
-        case ENTER:    /* enter */
-            history_len--;
-            free(history[history_len]);
-            if (mlmode) linenoiseEditMoveEnd(&l);
-            return (int)l.len;
-        case CTRL_C:     /* ctrl-c */
-            errno = EAGAIN;
-            return -1;
-        case BACKSPACE:   /* backspace */
-        case 8:     /* ctrl-h */
-            linenoiseEditBackspace(&l);
-            break;
-        case CTRL_D:     /* ctrl-d, remove char at right of cursor, or if the
-                            line is empty, act as end-of-file. */
-            if (l.len > 0) {
-                linenoiseEditDelete(&l);
-            } else {
+        if (vimode && viesc) {
+            switch(c) {
+                case '0':
+                    linenoiseEditMoveHome(&l);
+                    break;
+                case '$':
+                    linenoiseEditMoveEnd(&l);
+                    break;
+                case 'a':
+                    viesc = 0;
+                    linenoiseEditMoveRight(&l);
+                    break;
+                case 'A':
+                    viesc = 0;
+                    linenoiseEditMoveEnd(&l);
+                    break;
+                case 'b':
+                case 'B':
+                    linenoiseEditMovePrevWord(&l);
+                    break;
+                case BACKSPACE:
+                    linenoiseEditBackspace(&l);
+                    break;
+                case 'c':
+                case 'C':
+                    viesc = 0;
+                    break;
+                case CTRL_C:
+                    errno = EAGAIN;
+                    return -1;
+                case 'd':
+                    if (read(l.ifd,seq,1) == -1) break;
+                    switch(seq[0]) {
+                    case 'b':
+                        linenoiseEditDeletePrevWord(&l);
+                        break;
+                    case 'd':
+                        buf[0] = '\0';
+                        l.len = l.pos = 0;
+                        refreshLine(&l);
+                        break;
+                    case 'l':
+                        linenoiseEditDelete(&l);
+                        break;
+                    case 'w':
+                        linenoiseEditDeleteNextWord(&l);
+                    default:
+                        break;
+                    }
+                    break;
+                case 'D':
+                    buf[l.pos] = '\0';
+                    l.len = l.pos;
+                    refreshLine(&l);
+                    break;
+                case ENTER:
+                    history_len--;
+                    free(history[history_len]);
+                    if (mlmode) linenoiseEditMoveEnd(&l);
+                    return (int)l.len;
+                case 'h':
+                    linenoiseEditMoveLeft(&l);
+                    break;
+                case 'i':
+                    viesc = 0;
+                    break;
+                case 'I':
+                    viesc = 0;
+                    linenoiseEditMoveHome(&l);
+                    break;
+                case 'j':
+                    linenoiseEditHistoryNext(&l, LINENOISE_HISTORY_NEXT);
+                    break;
+                case 'k':
+                    linenoiseEditHistoryNext(&l, LINENOISE_HISTORY_PREV);
+                    break;
+                case 'l':
+                    linenoiseEditMoveRight(&l);
+                    break;
+                case 'w':
+                case 'W':
+                    linenoiseEditMoveNextWord(&l);
+                    break;
+                default:
+                    break;
+            }
+        } else {
+            switch(c) {
+            case ENTER:    /* enter */
                 history_len--;
                 free(history[history_len]);
+                if (mlmode) linenoiseEditMoveEnd(&l);
+                return (int)l.len;
+            case CTRL_C:     /* ctrl-c */
+                errno = EAGAIN;
                 return -1;
-            }
-            break;
-        case CTRL_T:    /* ctrl-t, swaps current character with previous. */
-            if (l.pos > 0 && l.pos < l.len) {
-                int aux = buf[l.pos-1];
-                buf[l.pos-1] = buf[l.pos];
-                buf[l.pos] = aux;
-                if (l.pos != l.len-1) l.pos++;
-                refreshLine(&l);
-            }
-            break;
-        case CTRL_B:     /* ctrl-b */
-            linenoiseEditMoveLeft(&l);
-            break;
-        case CTRL_F:     /* ctrl-f */
-            linenoiseEditMoveRight(&l);
-            break;
-        case CTRL_P:    /* ctrl-p */
-            linenoiseEditHistoryNext(&l, LINENOISE_HISTORY_PREV);
-            break;
-        case CTRL_N:    /* ctrl-n */
-            linenoiseEditHistoryNext(&l, LINENOISE_HISTORY_NEXT);
-            break;
-        case ESC:    /* escape sequence */
-            /* Read the next two bytes representing the escape sequence.
-             * Use two calls to handle slow terminals returning the two
-             * chars at different times. */
-            if (read(l.ifd,seq,1) == -1) break;
-            if (read(l.ifd,seq+1,1) == -1) break;
-
-            /* ESC [ sequences. */
-            if (seq[0] == '[') {
-                if (seq[1] >= '0' && seq[1] <= '9') {
-                    /* Extended escape, read additional byte. */
-                    if (read(l.ifd,seq+2,1) == -1) break;
-                    if (seq[2] == '~') {
+            case BACKSPACE:   /* backspace */
+            case 8:     /* ctrl-h */
+                linenoiseEditBackspace(&l);
+                break;
+            case CTRL_D:     /* ctrl-d, remove char at right of cursor, or if the
+                                line is empty, act as end-of-file. */
+                if (l.len > 0) {
+                    linenoiseEditDelete(&l);
+                } else {
+                    history_len--;
+                    free(history[history_len]);
+                    return -1;
+                }
+                break;
+            case CTRL_T:    /* ctrl-t, swaps current character with previous. */
+                if (l.pos > 0 && l.pos < l.len) {
+                    int aux = buf[l.pos-1];
+                    buf[l.pos-1] = buf[l.pos];
+                    buf[l.pos] = aux;
+                    if (l.pos != l.len-1) l.pos++;
+                    refreshLine(&l);
+                }
+                break;
+            case CTRL_B:     /* ctrl-b */
+                linenoiseEditMoveLeft(&l);
+                break;
+            case CTRL_F:     /* ctrl-f */
+                linenoiseEditMoveRight(&l);
+                break;
+            case CTRL_P:    /* ctrl-p */
+                linenoiseEditHistoryNext(&l, LINENOISE_HISTORY_PREV);
+                break;
+            case CTRL_N:    /* ctrl-n */
+                linenoiseEditHistoryNext(&l, LINENOISE_HISTORY_NEXT);
+                break;
+            case ESC:    /* escape sequence */
+                /* Read the next two bytes representing the escape sequence.
+                 * Use two calls to handle slow terminals returning the two
+                 * chars at different times. */
+                if (vimode) {
+                    linenoiseEditMoveLeft(&l);
+                    viesc = 1;
+                    break;
+                }
+                if (read(l.ifd,seq,1) == -1) break;
+                if (read(l.ifd,seq+1,1) == -1) break;
+    
+                /* ESC [ sequences. */
+                if (seq[0] == '[') {
+                    if (seq[1] >= '0' && seq[1] <= '9') {
+                        /* Extended escape, read additional byte. */
+                        if (read(l.ifd,seq+2,1) == -1) break;
+                        if (seq[2] == '~') {
+                            switch(seq[1]) {
+                            case '3': /* Delete key. */
+                                linenoiseEditDelete(&l);
+                                break;
+                            }
+                        }
+                    } else {
                         switch(seq[1]) {
-                        case '3': /* Delete key. */
-                            linenoiseEditDelete(&l);
+                        case 'A': /* Up */
+                            linenoiseEditHistoryNext(&l, LINENOISE_HISTORY_PREV);
+                            break;
+                        case 'B': /* Down */
+                            linenoiseEditHistoryNext(&l, LINENOISE_HISTORY_NEXT);
+                            break;
+                        case 'C': /* Right */
+                            linenoiseEditMoveRight(&l);
+                            break;
+                        case 'D': /* Left */
+                            linenoiseEditMoveLeft(&l);
+                            break;
+                        case 'H': /* Home */
+                            linenoiseEditMoveHome(&l);
+                            break;
+                        case 'F': /* End*/
+                            linenoiseEditMoveEnd(&l);
                             break;
                         }
                     }
-                } else {
+                }
+    
+                /* ESC O sequences. */
+                else if (seq[0] == 'O') {
                     switch(seq[1]) {
-                    case 'A': /* Up */
-                        linenoiseEditHistoryNext(&l, LINENOISE_HISTORY_PREV);
-                        break;
-                    case 'B': /* Down */
-                        linenoiseEditHistoryNext(&l, LINENOISE_HISTORY_NEXT);
-                        break;
-                    case 'C': /* Right */
-                        linenoiseEditMoveRight(&l);
-                        break;
-                    case 'D': /* Left */
-                        linenoiseEditMoveLeft(&l);
-                        break;
                     case 'H': /* Home */
                         linenoiseEditMoveHome(&l);
                         break;
@@ -854,46 +1001,34 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
                         break;
                     }
                 }
+                break;
+            default:
+                if (linenoiseEditInsert(&l,c)) return -1;
+                break;
+            case CTRL_U: /* Ctrl+u, delete the whole line. */
+                buf[0] = '\0';
+                l.pos = l.len = 0;
+                refreshLine(&l);
+                break;
+            case CTRL_K: /* Ctrl+k, delete from current to end of line. */
+                buf[l.pos] = '\0';
+                l.len = l.pos;
+                refreshLine(&l);
+                break;
+            case CTRL_A: /* Ctrl+a, go to the start of the line */
+                linenoiseEditMoveHome(&l);
+                break;
+            case CTRL_E: /* ctrl+e, go to the end of the line */
+                linenoiseEditMoveEnd(&l);
+                break;
+            case CTRL_L: /* ctrl+l, clear screen */
+                linenoiseClearScreen();
+                refreshLine(&l);
+                break;
+            case CTRL_W: /* ctrl+w, delete previous word */
+                linenoiseEditDeletePrevWord(&l);
+                break;
             }
-
-            /* ESC O sequences. */
-            else if (seq[0] == 'O') {
-                switch(seq[1]) {
-                case 'H': /* Home */
-                    linenoiseEditMoveHome(&l);
-                    break;
-                case 'F': /* End*/
-                    linenoiseEditMoveEnd(&l);
-                    break;
-                }
-            }
-            break;
-        default:
-            if (linenoiseEditInsert(&l,c)) return -1;
-            break;
-        case CTRL_U: /* Ctrl+u, delete the whole line. */
-            buf[0] = '\0';
-            l.pos = l.len = 0;
-            refreshLine(&l);
-            break;
-        case CTRL_K: /* Ctrl+k, delete from current to end of line. */
-            buf[l.pos] = '\0';
-            l.len = l.pos;
-            refreshLine(&l);
-            break;
-        case CTRL_A: /* Ctrl+a, go to the start of the line */
-            linenoiseEditMoveHome(&l);
-            break;
-        case CTRL_E: /* ctrl+e, go to the end of the line */
-            linenoiseEditMoveEnd(&l);
-            break;
-        case CTRL_L: /* ctrl+l, clear screen */
-            linenoiseClearScreen();
-            refreshLine(&l);
-            break;
-        case CTRL_W: /* ctrl+w, delete previous word */
-            linenoiseEditDeletePrevWord(&l);
-            break;
         }
     }
     return l.len;
@@ -980,6 +1115,11 @@ char *linenoise(const char *prompt) {
         if (count == -1) return NULL;
         return strdup(buf);
     }
+}
+
+char *linenoisevi(const char *prompt) {
+    vimode = 1;
+    return linenoise(prompt);
 }
 
 /* ================================ History ================================= */

--- a/linenoise.h
+++ b/linenoise.h
@@ -53,6 +53,7 @@ void linenoiseSetCompletionCallback(linenoiseCompletionCallback *);
 void linenoiseAddCompletion(linenoiseCompletions *, const char *);
 
 char *linenoise(const char *prompt);
+char *linenoisevi(const char *prompt);
 int linenoiseHistoryAdd(const char *line);
 int linenoiseHistorySetMaxLen(int len);
 int linenoiseHistorySave(const char *filename);


### PR DESCRIPTION
This change introduces vi bindings while maintaining the original API. A shim function was created that enables vi mode then passes off to the normal API, linenoise().

A few additional functions were created to support common key actions, including:
- linenoiseEditMovePrevWord
- linenoiseEditMoveNextWord
- linenoiseEditDeleteNextWord

The bindings are not meant to be comprehensive but to provide basic functionality by implementing the most common actions.

`example.c` was also updated to introduce a new flag that enables vi bindings.
