### PR TITLE
Mechanism for other threads to suspend linenoise() when needed

### DIFF
--- a/linenoise.h
+++ b/linenoise.h
@@ -61,6 +61,10 @@ void linenoiseClearScreen(void);
 void linenoiseSetMultiLine(int ml);
 void linenoisePrintKeyCodes(void);
 
+void linenoiseInit(void);
+void linenoisePause(void);
+void linenoiseResume(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
I'm using linenoise in a debugging tool that wants to be able to asynchronously
print a status message from time to time without making a mess of the input
area.  I added this functionality to allow that to happen.  Throwing it out here
as a pull request in case it's of interest to others.

Currently this is featurized behind the LINENOISE_INTERRUPTIBLE
define.  When not defined, linenoise is effectively unmodified.

linenoiseInit()
   Sets up pipe used for signaling.

linenoisePause()
   If linenoise() is active, it is paused, the current line is
   cleared, and raw mode is exited.  Output to stdout may be
   accomplished without messing up the display.  To allow
   linenoise to continue processing, linenoiseResume() must
   be called once output is done.

linenoiseResume()
   If linenoise() was active, restores the console to raw
   mode, repaints the line being edited, and allows linenoise
   processing to continue.