### PR TITLE
Added runtime history access.

### DIFF
--- a/example.c
+++ b/example.c
@@ -53,8 +53,16 @@ int main(int argc, char **argv) {
             linenoiseHistorySave("history.txt"); /* Save the history on disk. */
         } else if (!strncmp(line,"/historylen",11)) {
             /* The "/historylen" command will change the history len. */
-            int len = atoi(line+11);
+            int len = atoi(line + 11);
             linenoiseHistorySetMaxLen(len);
+        } else if (!strncmp(line,"/history",8)) {
+            /* Display the current history. */
+            for (int index = 0; ; ++index) {
+                char * hist = linenoiseHistoryLine(index);
+                if (hist == NULL) break;
+                printf("%4d: %s\n", index, hist);
+                free(hist);
+            }
         } else if (line[0] == '/') {
             printf("Unreconized command: %s\n", line);
         }

--- a/linenoise.c
+++ b/linenoise.c
@@ -1070,6 +1070,14 @@ int linenoiseHistorySetMaxLen(int len) {
     return 1;
 }
 
+/* Fetch a line of the history by (zero-based) index.  If the requested
+ * line does not exist, NULL is returned.  The return value is a heap-allocated
+ * copy of the line, and the caller is responsible for de-allocating it. */
+char * linenoiseHistoryLine(const int index) {
+    if (index < 0 || index >= history_len) return NULL;
+    return strdup(history[index]);
+}
+
 /* Save the history in the specified file. On success 0 is returned
  * otherwise -1 is returned. */
 int linenoiseHistorySave(const char *filename) {

--- a/linenoise.h
+++ b/linenoise.h
@@ -53,6 +53,7 @@ void linenoiseSetCompletionCallback(linenoiseCompletionCallback *);
 void linenoiseAddCompletion(linenoiseCompletions *, const char *);
 
 char *linenoise(const char *prompt);
+char *linenoiseHistoryLine(const int index);
 int linenoiseHistoryAdd(const char *line);
 int linenoiseHistorySetMaxLen(int len);
 int linenoiseHistorySave(const char *filename);


### PR DESCRIPTION
Added `linenoiseHistoryLine` function to get a copy of a line from the history, and added code to the example to demonstrate it.