### PR TITLE
Add option to list all alternatives instead of rotating them on the same line

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,6 +8,7 @@ MongoDB, and Android.
 * Completion.
 * About 1,100 lines of BSD license source code.
 * Only uses a subset of VT100 escapes (ANSI.SYS compatible).
+* Tab can be configured to either rotate all completion options on one line, or list all alternatives.
 
 ## Can a line editing library be 20k lines of code?
 

--- a/example.c
+++ b/example.c
@@ -9,6 +9,14 @@ void completion(const char *buf, linenoiseCompletions *lc) {
         linenoiseAddCompletion(lc,"hello");
         linenoiseAddCompletion(lc,"hello there");
     }
+    if (buf[0] == 'e') {
+        linenoiseAddCompletion(lc,"example here");
+        linenoiseAddCompletion(lc,"example there");
+        linenoiseAddCompletion(lc,"example everywhere");
+    }
+    if (buf[0] == 'c') {
+        linenoiseAddCompletion(lc,"cello");
+    }
 }
 
 int main(int argc, char **argv) {
@@ -25,6 +33,8 @@ int main(int argc, char **argv) {
         } else if (!strcmp(*argv,"--keycodes")) {
             linenoisePrintKeyCodes();
             exit(0);
+        } else if (!strcmp(*argv,"--list-all")) {
+            linenoiseSetListAll(1);
         } else {
             fprintf(stderr, "Usage: %s [--multiline] [--keycodes]\n", prgname);
             exit(1);

--- a/linenoise.h
+++ b/linenoise.h
@@ -59,6 +59,7 @@ int linenoiseHistorySave(const char *filename);
 int linenoiseHistoryLoad(const char *filename);
 void linenoiseClearScreen(void);
 void linenoiseSetMultiLine(int ml);
+void linenoiseSetListAll(int listAll);
 void linenoisePrintKeyCodes(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Many command interfaces list all alternatives below the prompt on TAB, so I added that functionality to linenoise. Now you can configure which way you want it to work.