### PR TITLE
Insert text for tab completion when there is only one completion.

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -380,6 +380,13 @@ static int completeLine(struct linenoiseState *ls) {
 
             switch(c) {
                 case 9: /* tab */
+		   if (lc.len == 1) {
+			   set_current(current,lc.cvec[0]);
+			   c = 0;
+			   stop = 1;
+			   break;
+		    }
+
                     i = (i+1) % (lc.len+1);
                     if (i == lc.len) linenoiseBeep();
                     break;


### PR DESCRIPTION
When the only choice is "foo", and the user hits <tab>, the
input buffer should fill with "foo", instead of showing that
"foo" is the only selection.