### PR TITLE
Include stddef.h for size_t (include what you use)

### DIFF
--- a/linenoise.h
+++ b/linenoise.h
@@ -39,6 +39,8 @@
 #ifndef __LINENOISE_H
 #define __LINENOISE_H
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Depending on your favorite include order, size_t will not be defined in linenoise.h. Impact of this change should be minimal, since we'll end up including stddef.h eventually anyways :)
