### PR TITLE
Enable tab completion in the middle

### DIFF
--- a/example.c
+++ b/example.c
@@ -4,10 +4,45 @@
 #include "linenoise.h"
 
 
-void completion(const char *buf, linenoiseCompletions *lc) {
-    if (buf[0] == 'h') {
-        linenoiseAddCompletion(lc,"hello");
-        linenoiseAddCompletion(lc,"hello there");
+void completion(const char *buf, linenoiseCompletions *lc, size_t pos) {
+    const char *term[] = {"hello", "hi", "hello there"}; /* lookup terms for completion */
+    const size_t n_terms = sizeof(term) / sizeof(char*); /* number of lookup terms */
+    size_t i, j, n, start, termlen;
+    char lookahread[1024];
+    char lookback[1024];
+    char newbuf[1024];
+
+    if (pos == 0)
+        return;
+
+    /* Find the start position to compare lookup terms. */
+    for (start = pos; (--start) != 0;) {
+        if (start > 0 && buf[start - 1] == ' ')
+            break;
+    }
+
+    /* For each lookup terms, see if it has prefix matches the input string. */
+    for (n = 0; n < n_terms; n++) {
+        termlen = strlen(term[n]);
+        for (i = start, j = 0; i < pos && j < termlen; i++, j++) {
+            if (buf[i] != term[n][j])
+                break;
+        }
+
+        /* If it matches, it is a completion option to add. */
+        if (i == pos) {
+            /* Setup the `lookback' buffer containing string before the
+             * position where lookup term being inserted. */
+            snprintf(lookback, start + 1, "%s", buf);
+            /* Setup the `lookahread' buffer containing string after the
+             * position where lookup term being inserted. */
+            strcpy(lookahread, buf + pos);
+            /* Concatenate everything. */
+            sprintf(newbuf, "%s%s%s", lookback, term[n], lookahread);
+
+            /* Add this completion option. */
+            linenoiseAddCompletion(lc, newbuf, start + termlen);
+        }
     }
 }
 

--- a/linenoise.h
+++ b/linenoise.h
@@ -46,15 +46,16 @@ extern "C" {
 typedef struct linenoiseCompletions {
   size_t len;
   char **cvec;
+  size_t *posvec;
 } linenoiseCompletions;
 
-typedef void(linenoiseCompletionCallback)(const char *, linenoiseCompletions *);
+typedef void(linenoiseCompletionCallback)(const char *, linenoiseCompletions *, size_t);
 typedef char*(linenoiseHintsCallback)(const char *, int *color, int *bold);
 typedef void(linenoiseFreeHintsCallback)(void *);
 void linenoiseSetCompletionCallback(linenoiseCompletionCallback *);
 void linenoiseSetHintsCallback(linenoiseHintsCallback *);
 void linenoiseSetFreeHintsCallback(linenoiseFreeHintsCallback *);
-void linenoiseAddCompletion(linenoiseCompletions *, const char *);
+void linenoiseAddCompletion(linenoiseCompletions *, const char *, size_t);
 
 char *linenoise(const char *prompt);
 void linenoiseFree(void *ptr);


### PR DESCRIPTION
Currently only the end of the line could be completed.
This functionality is done by changing:

1. Pass an additional "pos" argument to the linenoiseCompletionCallback
typedef, this will enable user to get cursor position from within the
completion code (in callback function).

2. Change the linenoiseAddCompletion() API and add "posvec" member to
its corresponding linenoiseCompletions structure and completeLine()
function so that we can save the cursor position (after the inserted
word) for each completion option rather than place cursor at the end
of line if a completion in the middle is chosen.

3. Use a slightly complicated completion() code in example.c, to show
how to achieve an much more useful completion callback that can do tab
completion in the middle.