### PR TITLE
Fix `comparison is always false' warning on ARM

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -792,7 +792,7 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
 
     if (write(l.ofd,prompt,l.plen) == -1) return -1;
     while(1) {
-        char c;
+        signed char c;
         int nread;
         char seq[3];
 


### PR DESCRIPTION
I use linenoise on an ARM device.  On ARM chars are unsigned by default and for this reason they can never be less than zero.