### PR TITLE
add funcion to save history in private file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -111,6 +111,7 @@ The followings are the history API calls:
     int linenoiseHistoryAdd(const char *line);
     int linenoiseHistorySetMaxLen(int len);
     int linenoiseHistorySave(const char *filename);
+    int linenoiseHistoryPrivSave(const char *filename);
     int linenoiseHistoryLoad(const char *filename);
 
 Use `linenoiseHistoryAdd` every time you want to add a new element
@@ -124,7 +125,9 @@ function.
 
 Linenoise has direct support for persisting the history into an history
 file. The functions `linenoiseHistorySave` and `linenoiseHistoryLoad` do
-just that. Both functions return -1 on error and 0 on success.
+just that. Both functions return -1 on error and 0 on success. You can also
+use `linenoiseHistoryPrivSave` to no group nor world access when creating
+a new history file.
 
 ## Completion
 

--- a/README.markdown
+++ b/README.markdown
@@ -127,7 +127,7 @@ Linenoise has direct support for persisting the history into an history
 file. The functions `linenoiseHistorySave` and `linenoiseHistoryLoad` do
 just that. Both functions return -1 on error and 0 on success. You can also
 use `linenoiseHistoryPrivSave` to no group nor world access when creating
-a new history file.
+a new history file on POSIX systems.
 
 ## Completion
 

--- a/README.markdown
+++ b/README.markdown
@@ -125,9 +125,12 @@ function.
 
 Linenoise has direct support for persisting the history into an history
 file. The functions `linenoiseHistorySave` and `linenoiseHistoryLoad` do
-just that. Both functions return -1 on error and 0 on success. You can also
-use `linenoiseHistoryPrivSave` to no group nor world access when creating
-a new history file on POSIX systems.
+just that. Both functions return -1 on error and 0 on success.
+
+On POSIX systems you can optionally use `linenoiseHistoryPrivSave` to force
+history file creation mode mask with 0077 (e.g. "u=rwx, g=, o="). This will
+block group and world from acessing a critical history file without changing
+the user or application's umask.
 
 ## Completion
 

--- a/linenoise.c
+++ b/linenoise.c
@@ -113,6 +113,7 @@
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include "linenoise.h"
 
@@ -1168,6 +1169,20 @@ int linenoiseHistorySave(const char *filename) {
         fprintf(fp,"%s\n",history[j]);
     fclose(fp);
     return 0;
+}
+
+/* Save the history in the specified file, uses no group nor world
+ * permissions when creating a new file.
+ * On success 0 is returned otherwise -1 is returned. */
+int linenoiseHistoryPrivSave(const char *filename) {
+    int rc;
+    mode_t cur_mask;
+
+    cur_mask = umask(S_IRWXG | S_IRWXO);
+    rc = linenoiseHistorySave(filename);
+    umask(cur_mask);
+
+    return rc;
 }
 
 /* Load the history from the specified file. If the file does not exist

--- a/linenoise.c
+++ b/linenoise.c
@@ -1171,6 +1171,7 @@ int linenoiseHistorySave(const char *filename) {
     return 0;
 }
 
+#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
 /* Save the history in the specified file, uses no group nor world
  * permissions when creating a new file.
  * On success 0 is returned otherwise -1 is returned. */
@@ -1184,6 +1185,7 @@ int linenoiseHistoryPrivSave(const char *filename) {
 
     return rc;
 }
+#endif
 
 /* Load the history from the specified file. If the file does not exist
  * zero is returned and no operation is performed.

--- a/linenoise.h
+++ b/linenoise.h
@@ -61,11 +61,14 @@ void linenoiseFree(void *ptr);
 int linenoiseHistoryAdd(const char *line);
 int linenoiseHistorySetMaxLen(int len);
 int linenoiseHistorySave(const char *filename);
-int linenoiseHistoryPrivSave(const char *filename);
 int linenoiseHistoryLoad(const char *filename);
 void linenoiseClearScreen(void);
 void linenoiseSetMultiLine(int ml);
 void linenoisePrintKeyCodes(void);
+
+#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+int linenoiseHistoryPrivSave(const char *filename);
+#endif
 
 #ifdef __cplusplus
 }

--- a/linenoise.h
+++ b/linenoise.h
@@ -61,6 +61,7 @@ void linenoiseFree(void *ptr);
 int linenoiseHistoryAdd(const char *line);
 int linenoiseHistorySetMaxLen(int len);
 int linenoiseHistorySave(const char *filename);
+int linenoiseHistoryPrivSave(const char *filename);
 int linenoiseHistoryLoad(const char *filename);
 void linenoiseClearScreen(void);
 void linenoiseSetMultiLine(int ml);


### PR DESCRIPTION
Function that guarantees no group nor world access when creating a new history file, but do not change the current file permission.

Closes #121