### PR TITLE
Fix various compiler warnings

### DIFF
--- a/example.c
+++ b/example.c
@@ -15,7 +15,12 @@ char *hints(const char *buf, int *color, int *bold) {
     if (!strcasecmp(buf,"hello")) {
         *color = 35;
         *bold = 0;
-        return " World";
+	/* The hints callback returns non-const, because it is possible to
+	 * dynamically allocate the hints we return, so long as we provide a
+	 * cleanup callback to linenoise that it can call later to deallocate
+	 * them. Here, we do not provide such a cleanup callback and we return a
+	 * static const - that's why we can cast this const away. */
+        return (char *)" World";
     }
     return NULL;
 }

--- a/linenoise.c
+++ b/linenoise.c
@@ -119,7 +119,7 @@
 
 #define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
 #define LINENOISE_MAX_LINE 4096
-static char *unsupported_term[] = {"dumb","cons25","emacs",NULL};
+static const char *unsupported_term[] = {"dumb","cons25","emacs",NULL};
 static linenoiseCompletionCallback *completionCallback = NULL;
 static linenoiseHintsCallback *hintsCallback = NULL;
 static linenoiseFreeHintsCallback *freeHintsCallback = NULL;
@@ -1004,17 +1004,18 @@ static char *linenoiseNoTTY(void) {
     size_t len = 0, maxlen = 0;
 
     while(1) {
+    	int c;
         if (len == maxlen) {
+            char *oldval = line;
             if (maxlen == 0) maxlen = 16;
             maxlen *= 2;
-            char *oldval = line;
             line = realloc(line,maxlen);
             if (line == NULL) {
                 if (oldval) free(oldval);
                 return NULL;
             }
         }
-        int c = fgetc(stdin);
+        c = fgetc(stdin);
         if (c == EOF || c == '\n') {
             if (c == EOF && len == 0) {
                 free(line);


### PR DESCRIPTION
I incorporated linenoise into some stuff I'm hacking, where the build is
using some fairly picky compiler flags. Fortunately, the changes required
to address the warnings were fairly minor.

* "[...] initialization discards 'const' [...]"
  (static char *unsupported_term[] = {"dumb","cons25","emacs",NULL};)
* "[...] ISO C90 forbids mixed declarations and code [...]"
* "[...] return discards 'const' qualifier from pointer target [...]"
  (return " World")

Signed-off-by: Geoff Thorpe <geoff@geoffthorpe.net>