### PR TITLE
Stop keyboard input on demand.

### DIFF
--- a/linenoise.h
+++ b/linenoise.h
@@ -65,6 +65,8 @@ int linenoiseHistoryLoad(const char *filename);
 void linenoiseClearScreen(void);
 void linenoiseSetMultiLine(int ml);
 void linenoisePrintKeyCodes(void);
+void linenoiseInputPollTime( int milliseconds );
+int linenoiseStopInput(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The modification allows one to stop keyboard input on demand.

This is necessary in a multi-threaded application that may have several reasons to exit even while the command line is active. The enclosed change uses pselect(), a user settable poll time and a flag that can be used to request that input be stopped. It appears to the library as if the user typed ^C.

The implementation retains compatibility with the existing system (works the same as before) unless the user sets the poll interval and calls the 'linenoiseStopInput()' function.