### PR TITLE
adds static library, man page, and install target to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 linenoise_example
+*.a
 *.dSYM
+*.o
 history.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-linenoise_example
 *.a
 *.dSYM
 *.o
+example
 history.txt

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PREFIX = /usr/local
+
 linenoise_example: linenoise.h linenoise.c
 
 linenoise_example: linenoise.c example.c
@@ -10,6 +12,12 @@ liblinenoise.a: linenoise.o
 
 .o:
 	$(CC) -Wall -W -Os -c $<
+
+install: liblinenoise.a linenoise.h
+	mkdir -p $(DESTDIR)$(PREFIX)/lib
+	cp liblinenoise.a $(DESTDIR)$(PREFIX)/lib/liblinenoise.a
+	mkdir -p $(DESTDIR)$(PREFIX)/include
+	cp linenoise.h $(DESTDIR)$(PREFIX)/include/linenoise.h
 
 clean:
 	rm -f linenoise_example liblinenoise.a linenoise.o

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SRC = linenoise.c
 OBJ = $(SRC:.c=.o)
 LIB = liblinenoise.a
 INC = linenoise.h
+MAN = linenoise.3
 
 all: $(LIB) example
 
@@ -18,11 +19,13 @@ example: example.o $(LIB)
 .c.o:
 	$(CC) $(CFLAGS) -c $<
 
-install: $(LIB) $(INC)
+install: $(LIB) $(INC) $(MAN)
 	mkdir -p $(DESTDIR)$(PREFIX)/lib
 	cp $(LIB) $(DESTDIR)$(PREFIX)/lib/$(LIB)
 	mkdir -p $(DESTDIR)$(PREFIX)/include
 	cp $(INC) $(DESTDIR)$(PREFIX)/include/$(INC)
+	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man3
+	cp $(MAN) $(DESTDIR)$(PREFIX)/share/man/man3/$(MAN)
 
 clean:
 	rm -f $(LIB) example example.o $(OBJ)

--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,13 @@ linenoise_example: linenoise.h linenoise.c
 linenoise_example: linenoise.c example.c
 	$(CC) -Wall -W -Os -g -o linenoise_example linenoise.c example.c
 
+lib: liblinenoise.a
+
+liblinenoise.a: linenoise.o
+	$(AR) -rcs liblinenoise.a linenoise.o
+
+.o:
+	$(CC) -Wall -W -Os -c $<
+
 clean:
-	rm -f linenoise_example
+	rm -f linenoise_example liblinenoise.a linenoise.o

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,28 @@
 PREFIX = /usr/local
+CC = cc
+CFLAGS = -Os -Wall -Wextra
 
-linenoise_example: linenoise.h linenoise.c
+SRC = linenoise.c
+OBJ = $(SRC:.c=.o)
+LIB = liblinenoise.a
+INC = linenoise.h
 
-linenoise_example: linenoise.c example.c
-	$(CC) -Wall -W -Os -g -o linenoise_example linenoise.c example.c
+all: $(LIB) example
 
-lib: liblinenoise.a
+$(LIB): $(OBJ)
+	$(AR) -rcs $@ $(OBJ)
 
-liblinenoise.a: linenoise.o
-	$(AR) -rcs liblinenoise.a linenoise.o
+example: example.o $(LIB)
+	$(CC) -o $@ example.o $(LIB)
 
-.o:
-	$(CC) -Wall -W -Os -c $<
+.c.o:
+	$(CC) $(CFLAGS) -c $<
 
-install: liblinenoise.a linenoise.h
+install: $(LIB) $(INC)
 	mkdir -p $(DESTDIR)$(PREFIX)/lib
-	cp liblinenoise.a $(DESTDIR)$(PREFIX)/lib/liblinenoise.a
+	cp $(LIB) $(DESTDIR)$(PREFIX)/lib/$(LIB)
 	mkdir -p $(DESTDIR)$(PREFIX)/include
-	cp linenoise.h $(DESTDIR)$(PREFIX)/include/linenoise.h
+	cp $(INC) $(DESTDIR)$(PREFIX)/include/$(INC)
 
 clean:
-	rm -f linenoise_example liblinenoise.a linenoise.o
+	rm -f $(LIB) example example.o $(OBJ)

--- a/README.markdown
+++ b/README.markdown
@@ -122,7 +122,7 @@ Note that for history to work, you have to set a length for the history
 a proper one). This is accomplished using the `linenoiseHistorySetMaxLen`
 function.
 
-Linenoise has direct support for persisting the history into an history
+Linenoise has direct support for persisting the history into a history
 file. The functions `linenoiseHistorySave` and `linenoiseHistoryLoad` do
 just that. Both functions return -1 on error and 0 on success.
 

--- a/linenoise.3
+++ b/linenoise.3
@@ -1,0 +1,148 @@
+.Dd $Mdocdate$
+.Dt linenoise 3
+.Os
+
+.Sh NAME
+.Nm linenoise
+.Nd readline replacement
+
+.Sh SYNOPSIS
+.In linenoise.h
+Link with
+.Ar -llinenoise
+
+.Ft char *
+.Fn linenoise "const char *prompt"
+.Ft void
+.Fn linenoiseFree "void *ptr"
+.Ft void
+.Fn linenoiseSetMultiLine "int ml"
+
+.Ft int
+.Fn linenoiseHistoryAdd "const char *line"
+.Ft int
+.Fn linenoiseHistorySetMaxLen "int len"
+.Ft int
+.Fn linenoiseHistorySave "const char *filename"
+.Ft int
+.Fn linenoiseHistoryLoad "const char *filename"
+
+.Ft void
+.Fn linenoiseSetCompletionCallback "linenoiseCompletionCallback *"
+.Ft void
+.Fn linenoiseAddCompletion "linenoiseCompletions *" "const char *"
+.Ft void
+.Fn linenoiseSetHintsCallback "linenoiseHintsCallback *"
+.Ft void
+.Fn linenoiseSetFreeHintsCallback "linenoiseFreeHintsCallback *"
+
+.Ft void
+.Fn linenoiseClearScreen "void"
+.Ft void
+.Fn linenoisePrintKeyCodes "void"
+
+.Sh DESCRIPTION
+.Fn linenoise
+shows the specified prompt to the user and takes input with line editing and
+history capabilities.
+It returns a buffer with the users input, or NULL on eof or out of memory.
+The buffer must be freed.
+
+.Fn linenoiseFree
+If your program uses a different dynamic allocation library, you may also use
+.Fn linenoiseFree
+to make sure the line is freed with the same allocator it was created.
+
+.Fn linenoiseSetMultiLine
+set or unset multiline editing, where multiple screens rows are used.
+Enable by passing `1` and disable with `0`.
+When disabled the text will scroll towards left as the user types more.
+
+.Fn linenoiseHistoryAdd
+adds a new element to the top of the history.
+It will be the first the user sees when using the up arrow.
+
+.Fn linenoiseHistorySetMaxLen
+sets a length for the history.
+Default is zero, meaning history is disabled.
+
+.Fn linenoiseHistorySave
+saves the history into a file, returning -1 on error and 0 on success.
+
+.Fn linenoiseHistoryLoad
+loads a history file, returning -1 on error and 0 on success.
+
+.Fn linenoiseSetCompletionCallback
+sets the callback function to be used when the user presses the TAB key.
+The callback is implemented like
+.Ft void
+.Fn completion "const char *buf" "linenoiseCompletions *lc"
+where buf is the users input and lc is used for adding completions.
+
+.Fn linenoiseAddCompletion
+may be used in the completion callback to add completions.
+It can be called several times to add to the list of completions
+
+.Fn linenoiseSetHintsCallback
+specifies a callback function that can be used for hints.
+Hints try to guess usefull completions to what the user is typing.
+the callback is implemented like
+.Ft char
+.Fn *hints "const char *buf" "int *color" "int *bold"
+where buf is the users input, color and bold specifies aesthetics.
+
+.Fn linenoiseSetFreeHintsCallback
+sets a deallocater to free the returned hint if it was dynamically allocated.
+
+.Fn linenoiseClearScreen
+clears the screen.
+
+.Fn linenoisePrintKeyCodes
+is used in debugging mode to print key codes.
+
+.Ss Input length
+When a tty is detected (user typing into terminal), maximum editable
+line length is `LINENOISE_MAX_LINE`,
+otherwise (pipes or redirection) there are no limits.
+
+.Ss xterm color terminal codes
+.Bd -literal
+    red = 31
+    green = 32
+    yellow = 33
+    blue = 34
+    magenta = 35
+    cyan = 36
+    white = 37;
+.Ed
+
+.Sh EXAMPLES
+.Ss Canonical loop in program using Linenoise
+.Bd -literal
+    while((line = linenoise("hello> ")) != NULL) {
+        printf("You wrote: %s\n", line);
+        linenoiseFree(line); /* Or free(line) for libc malloc. */
+    }
+.Ed
+
+.Ss Completion callback function
+.Bd -literal
+    void completion(const char *buf, linenoiseCompletions *lc) {
+        if (buf[0] == 'h') {
+            linenoiseAddCompletion(lc,"hello");
+            linenoiseAddCompletion(lc,"hello there");
+        }
+    }
+.Ed
+
+.Ss Hint callback function
+.Bd -literal
+    char *hints(const char *buf, int *color, int *bold) {
+        if (!strcasecmp(buf,"git remote add")) {
+            *color = 35;
+            *bold = 0;
+            return " <name> <url>";
+        }
+        return NULL;
+    }
+.Ed


### PR DESCRIPTION
I would like to be able to use the library as all other libraries,
by linking with -l and <including.h>.
By copying 1000 SLOC into my projects, I would clutter them
and also miss new updates.
I also changed a few things, but if you don't like them they should hopefully
be trivial to revert.