### PR TITLE
TERM=null likely means no escape sequence support

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -208,7 +208,7 @@ static int isUnsupportedTerm(void) {
     char *term = getenv("TERM");
     int j;
 
-    if (term == NULL) return 0;
+    if (term == NULL) return 1;
     for (j = 0; unsupported_term[j]; j++)
         if (!strcasecmp(term,unsupported_term[j])) return 1;
     return 0;


### PR DESCRIPTION
Currently if the TERM is null, it is counted as a terminal
which supports escape sequences. However if no TERM is set,
the likelihood is that escape sequences are not supported.

For instance CLion's integrated terminate does not support escape
sequences and does not set a TERM.

With this change an application goes from displaying:

![db34bf7c-13c6-11e7-93b0-0974fad154ee](https://cloud.githubusercontent.com/assets/236641/24444334/da859adc-145d-11e7-94a5-989e453569d3.png)

To displaying:

![0f0dc03c-13c7-11e7-9337-d25d20d38c23](https://cloud.githubusercontent.com/assets/236641/24444340/e0bbe186-145d-11e7-92f4-12582b57c488.png)
