### PR TITLE
add support for \e[1~ and \e[4~ escapes

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -880,6 +880,12 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
                         case '3': /* Delete key. */
                             linenoiseEditDelete(&l);
                             break;
+                        case '1': /* Home */
+                            linenoiseEditMoveHome(&l);
+                            break;
+                        case '4': /* End */
+                            linenoiseEditMoveEnd(&l);
+                            break;
                         }
                     }
                 } else {


### PR DESCRIPTION
Those are default escapes for home/end on putty.