### PR TITLE
linenoiseRemoteRefereshLine()

### DIFF
--- a/linenoise.h
+++ b/linenoise.h
@@ -65,6 +65,7 @@ int linenoiseHistoryLoad(const char *filename);
 void linenoiseClearScreen(void);
 void linenoiseSetMultiLine(int ml);
 void linenoisePrintKeyCodes(void);
+void linenoiseRemoteRefreshLine(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
We've been using linenoise in a larger multi-threaded project. When another thread uses printf to display some message and a linenoise prompt is on the screen, the message prints at the end of our current prompt, and no new prompt is displayed resulting in ugly output.

Our new function allows other processes to remotely refresh the linenoise line. Thereby they can print their string on its own line, then reshesh the prompt so everything looks nice.

This is accomplished by replacing read in several places with a function that uses select to wait on two file descriptors, stdin and a control pipe that we create. linenoiseRemoteRefreshLine() pushes a new control
character (ctrl-r) into our control pipe; when that is received, a flag is set that calls for refresh line to be called.