### PR TITLE
CMake and Build as System Library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,18 @@
 linenoise_example
 *.dSYM
 history.txt
+
+# Libs
+*.so
+*.a
+
+# CMAKE
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(linenoise)
+
+set(SOURCES linenoise.c)
+
+add_library(linenoise SHARED ${SOURCES})
+add_library(linenoise-static STATIC ${SOURCES})
+add_executable(linenoise_example example.c)
+target_link_libraries(linenoise_example linenoise)
+
+install (TARGETS linenoise DESTINATION lib)
+install (FILES linenoise.h DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,4 +10,5 @@ add_executable(linenoise_example example.c)
 target_link_libraries(linenoise_example linenoise)
 
 install (TARGETS linenoise DESTINATION lib)
+install (TARGETS linenoise-static DESTINATION lib)
 install (FILES linenoise.h DESTINATION include)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,0 @@
-linenoise_example: linenoise.h linenoise.c
-
-linenoise_example: linenoise.c example.c
-	$(CC) -Wall -W -Os -g -o linenoise_example linenoise.c example.c
-
-clean:
-	rm -f linenoise_example


### PR DESCRIPTION
I created a cmake file to enable integration of this with a larger cmake project using ExternalProject. This maintains compatibility. This also allows linenoise to be installed a system library and dynamically linked. I am willing to add conditional compilation for the static target.