### PR TITLE
Fixed two Coverity defects

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -485,6 +485,8 @@ void refreshShowHints(struct abuf *ab, struct linenoiseState *l, int plen) {
             if (bold == 1 && color == -1) color = 37;
             if (color != -1 || bold != 0)
                 snprintf(seq,64,"\033[%d;%d;49m",bold,color);
+            else
+                seq[0] = '\0';
             abAppend(ab,seq,strlen(seq));
             abAppend(ab,hint,hintlen);
             if (color != -1 || bold != 0)
@@ -1168,7 +1170,11 @@ int linenoiseHistorySave(const char *filename) {
     fp = fopen(filename,"w");
     umask(old_umask);
     if (fp == NULL) return -1;
-    chmod(filename,S_IRUSR|S_IWUSR);
+    if (chmod(filename,S_IRUSR|S_IWUSR) < 0) {
+        fclose(fp);
+        unlink(filename);
+        return -1;
+    }
     for (j = 0; j < history_len; j++)
         fprintf(fp,"%s\n",history[j]);
     fclose(fp);


### PR DESCRIPTION
1) `strlen()` on uninitialized string
2) Ignoring the return value of `chmod()`