### PR TITLE
Set seq to empty string if color/bold not used

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -485,6 +485,8 @@ void refreshShowHints(struct abuf *ab, struct linenoiseState *l, int plen) {
             if (bold == 1 && color == -1) color = 37;
             if (color != -1 || bold != 0)
                 snprintf(seq,64,"\033[%d;%d;49m",bold,color);
+            else
+                seq[0] = '\0';
             abAppend(ab,seq,strlen(seq));
             abAppend(ab,hint,hintlen);
             if (color != -1 || bold != 0)


### PR DESCRIPTION
Otherwise the subsequent `abAppend` will concatenate whatever junk data
is in seq to ab