### PR TITLE
Shared library support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 linenoise_example
 *.dSYM
 history.txt
+
+liblinenoise.*
+*.o

--- a/GNUmakefile.libs
+++ b/GNUmakefile.libs
@@ -1,0 +1,45 @@
+PREFIX     ?= /usr/local
+INCLUDEDIR ?= $(PREFIX)/include
+LIBDIR     ?= $(PREFIX)/lib
+
+SOURCES = linenoise.c
+HEADERS = $(SOURCES:%.c=%.h)
+OBJECTS = $(SOURCES:%.c=%.o)
+
+LIBVERSION = 0.0.0
+
+SHLIBNAME = liblinenoise.so.$(LIBVERSION)
+SONAME    = liblinenoise.so.$(word 1, $(subst ., ,$(LIBVERSION)))
+STLIBNAME = liblinenoise.a
+
+LD = $(CC)
+
+DEFAULT_CPPFLAGS =
+DEFAULT_CFLAGS   = -Wall -W -O2 -g -fPIC
+DEFAULT_LDFLAGS  = -shared -Wl,-soname,$(SONAME)
+
+all: $(SHLIBNAME) $(STLIBNAME)
+
+$(SHLIBNAME): $(OBJECTS)
+	$(LD) $(DEFAULT_LDFLAGS) $(LDFLAGS) $^ -o $@
+
+$(STLIBNAME): $(OBJECTS)
+	$(AR) $(ARFLAGS) $@ $^
+
+$(OBJECTS) : %.o : %.c
+	$(CC) $(DEFAULT_CPPFLAGS) $(CPPFLAGS) $(DEFAULT_CFLAGS) $(CFLAGS) \
+		-c $< -o $@
+
+install: $(SHLIBNAME)
+	install -d $(DESTDIR)$(INCLUDEDIR)
+	install -m 0644 $(HEADERS) $(DESTDIR)$(INCLUDEDIR)
+	install -d $(DESTDIR)$(LIBDIR)
+	install -m 0644 $(STLIBNAME) $(DESTDIR)$(LIBDIR)
+	install -m 0755 $(SHLIBNAME) $(DESTDIR)$(LIBDIR)
+	ln -sf  $(SHLIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
+	ln -sf  $(SHLIBNAME) $(DESTDIR)$(LIBDIR)/liblinenoise.so
+
+clean:
+	rm -f $(SHLIBNAME) $(STLIBNAME) $(OBJECTS)
+
+.PHONY: all clean install

--- a/GNUmakefile.libs
+++ b/GNUmakefile.libs
@@ -16,7 +16,7 @@ LD = $(CC)
 
 DEFAULT_CPPFLAGS =
 DEFAULT_CFLAGS   = -Wall -W -O2 -g -fPIC
-DEFAULT_LDFLAGS  = -shared -Wl,-soname,$(SONAME)
+DEFAULT_LDFLAGS  = -shared -Wl,-soname,$(SONAME) -Wl,--version-script=symbol.map
 
 all: $(SHLIBNAME) $(STLIBNAME)
 

--- a/linenoise.c
+++ b/linenoise.c
@@ -473,7 +473,7 @@ static void abFree(struct abuf *ab) {
 
 /* Helper of refreshSingleLine() and refreshMultiLine() to show hints
  * to the right of the prompt. */
-void refreshShowHints(struct abuf *ab, struct linenoiseState *l, int plen) {
+static void refreshShowHints(struct abuf *ab, struct linenoiseState *l, int plen) {
     char seq[64];
     if (hintsCallback && plen+l->len < l->cols) {
         int color = -1, bold = 0;
@@ -637,7 +637,7 @@ static void refreshLine(struct linenoiseState *l) {
 /* Insert the character 'c' at cursor current position.
  *
  * On error writing to the terminal -1 is returned, otherwise 0. */
-int linenoiseEditInsert(struct linenoiseState *l, char c) {
+static int linenoiseEditInsert(struct linenoiseState *l, char c) {
     if (l->len < l->buflen) {
         if (l->len == l->pos) {
             l->buf[l->pos] = c;
@@ -664,7 +664,7 @@ int linenoiseEditInsert(struct linenoiseState *l, char c) {
 }
 
 /* Move cursor on the left. */
-void linenoiseEditMoveLeft(struct linenoiseState *l) {
+static void linenoiseEditMoveLeft(struct linenoiseState *l) {
     if (l->pos > 0) {
         l->pos--;
         refreshLine(l);
@@ -672,7 +672,7 @@ void linenoiseEditMoveLeft(struct linenoiseState *l) {
 }
 
 /* Move cursor on the right. */
-void linenoiseEditMoveRight(struct linenoiseState *l) {
+static void linenoiseEditMoveRight(struct linenoiseState *l) {
     if (l->pos != l->len) {
         l->pos++;
         refreshLine(l);
@@ -680,7 +680,7 @@ void linenoiseEditMoveRight(struct linenoiseState *l) {
 }
 
 /* Move cursor to the start of the line. */
-void linenoiseEditMoveHome(struct linenoiseState *l) {
+static void linenoiseEditMoveHome(struct linenoiseState *l) {
     if (l->pos != 0) {
         l->pos = 0;
         refreshLine(l);
@@ -688,7 +688,7 @@ void linenoiseEditMoveHome(struct linenoiseState *l) {
 }
 
 /* Move cursor to the end of the line. */
-void linenoiseEditMoveEnd(struct linenoiseState *l) {
+static void linenoiseEditMoveEnd(struct linenoiseState *l) {
     if (l->pos != l->len) {
         l->pos = l->len;
         refreshLine(l);
@@ -699,7 +699,7 @@ void linenoiseEditMoveEnd(struct linenoiseState *l) {
  * entry as specified by 'dir'. */
 #define LINENOISE_HISTORY_NEXT 0
 #define LINENOISE_HISTORY_PREV 1
-void linenoiseEditHistoryNext(struct linenoiseState *l, int dir) {
+static void linenoiseEditHistoryNext(struct linenoiseState *l, int dir) {
     if (history_len > 1) {
         /* Update the current history entry before to
          * overwrite it with the next one. */
@@ -723,7 +723,7 @@ void linenoiseEditHistoryNext(struct linenoiseState *l, int dir) {
 
 /* Delete the character at the right of the cursor without altering the cursor
  * position. Basically this is what happens with the "Delete" keyboard key. */
-void linenoiseEditDelete(struct linenoiseState *l) {
+static void linenoiseEditDelete(struct linenoiseState *l) {
     if (l->len > 0 && l->pos < l->len) {
         memmove(l->buf+l->pos,l->buf+l->pos+1,l->len-l->pos-1);
         l->len--;
@@ -733,7 +733,7 @@ void linenoiseEditDelete(struct linenoiseState *l) {
 }
 
 /* Backspace implementation. */
-void linenoiseEditBackspace(struct linenoiseState *l) {
+static void linenoiseEditBackspace(struct linenoiseState *l) {
     if (l->pos > 0 && l->len > 0) {
         memmove(l->buf+l->pos-1,l->buf+l->pos,l->len-l->pos);
         l->pos--;
@@ -745,7 +745,7 @@ void linenoiseEditBackspace(struct linenoiseState *l) {
 
 /* Delete the previosu word, maintaining the cursor at the start of the
  * current word. */
-void linenoiseEditDeletePrevWord(struct linenoiseState *l) {
+static void linenoiseEditDeletePrevWord(struct linenoiseState *l) {
     size_t old_pos = l->pos;
     size_t diff;
 

--- a/symbol.map
+++ b/symbol.map
@@ -1,0 +1,19 @@
+LINENOISE_0.0 {
+global:
+  linenoiseSetCompletionCallback;
+  linenoiseSetHintsCallback;
+  linenoiseSetFreeHintsCallback;
+  linenoiseAddCompletion;
+  linenoise;
+  linenoiseFree;
+  linenoiseHistoryAdd;
+  linenoiseHistorySetMaxLen;
+  linenoiseHistorySave;
+  linenoiseHistoryLoad;
+  linenoiseClearScreen;
+  linenoiseSetMultiLine;
+  linenoisePrintKeyCodes;
+
+local:
+  *;
+};


### PR DESCRIPTION
This change-set provides support for building and installing shared and static libraries.  I used a separate makefile for the new targets because they require GNU make, which is not true of the existing makefile.

If these changes are welcome, is compatibility with non-GNU makes is important (given that the existing makefile is  just used for compiling an example programme) or shall I do away with the separate makefile?