### PR TITLE
Rewrote the calculation of prompt length, ignoring length of ANSI esc…

### DIFF
--- a/example.c
+++ b/example.c
@@ -55,7 +55,8 @@ int main(int argc, char **argv) {
      *
      * The typed string is returned as a malloc() allocated string by
      * linenoise, so the user needs to free() it. */
-    while((line = linenoise("hello> ")) != NULL) {
+    const char *prompt = "\033[01;33mhello\033[0m>> ";
+    while((line = linenoise(prompt)) != NULL) {
         /* Do something with the string. */
         if (line[0] != '\0' && line[0] != '/') {
             printf("echo: '%s'\n", line);


### PR DESCRIPTION
Using strlen() to calculate the length of the prompt leads to mispositions of the cursor when the prompt passed in by users include ANSI escape codes (specifying prompt colors etc.). So I added a pstrlen() function to do the calculation of prompt, sort of solved the problem.

Before:
![before](https://user-images.githubusercontent.com/35718816/75428892-d9547480-5983-11ea-923e-6e9640e5a578.png)


After:
![after](https://user-images.githubusercontent.com/35718816/75429108-351efd80-5984-11ea-9899-e182a20c483b.png)

