### PR TITLE
add mask input mode

### DIFF
--- a/example.c
+++ b/example.c
@@ -55,6 +55,7 @@ int main(int argc, char **argv) {
      *
      * The typed string is returned as a malloc() allocated string by
      * linenoise, so the user needs to free() it. */
+    
     while((line = linenoise("hello> ")) != NULL) {
         /* Do something with the string. */
         if (line[0] != '\0' && line[0] != '/') {
@@ -65,6 +66,10 @@ int main(int argc, char **argv) {
             /* The "/historylen" command will change the history len. */
             int len = atoi(line+11);
             linenoiseHistorySetMaxLen(len);
+        } else if (!strncmp(line, "/mask", 5)) {
+            linenoiseMaskModeEnable();
+        } else if (!strncmp(line, "/unmask", 7)) {
+            linenoiseMaskModeDisable();
         } else if (line[0] == '/') {
             printf("Unreconized command: %s\n", line);
         }

--- a/linenoise.h
+++ b/linenoise.h
@@ -66,6 +66,9 @@ void linenoiseClearScreen(void);
 void linenoiseSetMultiLine(int ml);
 void linenoisePrintKeyCodes(void);
 
+void linenoiseMaskModeEnable();
+void linenoiseMaskModeDisable();
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
As mentioned in https://github.com/antirez/redis/pull/6834
I try to add mask input mode to linenoise.
Add two functions:
`linenoiseMaskModeEnable`
`linenoiseMaskModeDisable`

And in `./linenoise_example`
You can use `/mask` to enable input masking, and use `/unmask` to disable it.

Signed-off-by: lifubang <lifubang@acmcoder.com>