### PR TITLE
fix masking input when there is no hintsCallback

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -669,7 +669,8 @@ int linenoiseEditInsert(struct linenoiseState *l, char c) {
             if ((!mlmode && l->plen+l->len < l->cols && !hintsCallback)) {
                 /* Avoid a full update of the line in the
                  * trivial case. */
-                if (write(l->ofd,&c,1) == -1) return -1;
+                char d = (maskmode==1) ? '*' : c;
+                if (write(l->ofd,&d,1) == -1) return -1;
             } else {
                 refreshLine(l);
             }


### PR DESCRIPTION
In example.c, there is a `hintsCallback`, but there is a bug when there is no `hintsCallback`.
Because we avoid a full update of the line in this case.
So we need to fix it.

Signed-off-by: lifubang <lifubang@acmcoder.com>