### PR TITLE
Fix compilation in non C99/C11 mode.

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -598,7 +598,8 @@ static void refreshMultiLine(struct linenoiseState *l) {
     /* Write the prompt and the current buffer content */
     abAppend(&ab,l->prompt,strlen(l->prompt));
     if (maskmode == 1) {
-        for (uint i = 0; i < l->len; i++) abAppend(&ab,"*",1);
+        uint i;
+        for (i = 0; i < l->len; i++) abAppend(&ab,"*",1);
     } else {
         abAppend(&ab,l->buf,l->len);
     }


### PR DESCRIPTION
This fixes an accidental drift towards C99/C11 dependencies.

Noticed this when Redis builds started to fail on older Debian systems (gcc 4.9.2). Apparently `deps/Makefile` also happens to not propagate `CFLAGS` so `-std=c11` is omitted, resulting with build failures:

```
[...]
MAKE linenoise
cd linenoise && make
make[3]: Entering directory '/work/redis-unstable/deps/linenoise'
cc  -Wall -Os -g  -c linenoise.c
linenoise.c: In function 'refreshMultiLine':
linenoise.c:601:9: error: 'for' loop initial declarations are only allowed in C99 or C11 mode
         for (uint i = 0; i < l->len; i++) abAppend(&ab,"*",1);
[...]
```
