### PR TITLE
Fix signed char issue on unsigned char systems

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -819,7 +819,7 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
 
     if (write(l.ofd,prompt,l.plen) == -1) return -1;
     while(1) {
-        char c;
+        signed char c;
         int nread;
         char seq[3];
 


### PR DESCRIPTION
There is an if (c < 0) check a few lines below which is always
false for systems that use the unsigned version of char. This
is allowed by the C standard and common on powerpc and arm
platforms.