### PR TITLE
lndebug: When in release mode, allow compilation by clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 linenoise_example
 *.dSYM
 history.txt
+
+tags

--- a/linenoise.c
+++ b/linenoise.c
@@ -193,7 +193,7 @@ FILE *lndebug_fp = NULL;
         fflush(lndebug_fp); \
     } while (0)
 #else
-#define lndebug(fmt, ...)
+#define lndebug(...)
 #endif
 
 /* ======================= Low level terminal handling ====================== */


### PR DESCRIPTION
`clang` with `-Wpedantic` and `-Werror` does not allow the following:

```c
#define printf_like_macro(fmt, ...) /* Something */

printf_like_macro("just one arg");
```
for security reasons.

This PR allows compilation under the following circumstances by removing the obligation of a format string (since it was not used by `lndebug` in the first place)