### PR TITLE
POC: Reverse history search

### DIFF
--- a/example.c
+++ b/example.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
      *
      * The typed string is returned as a malloc() allocated string by
      * linenoise, so the user needs to free() it. */
-    
+
     while((line = linenoise("hello> ")) != NULL) {
         /* Do something with the string. */
         if (line[0] != '\0' && line[0] != '/') {

--- a/example.c
+++ b/example.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
      *
      * The typed string is returned as a malloc() allocated string by
      * linenoise, so the user needs to free() it. */
-
+    
     while((line = linenoise("hello> ")) != NULL) {
         /* Do something with the string. */
         if (line[0] != '\0' && line[0] != '/') {

--- a/linenoise.c
+++ b/linenoise.c
@@ -770,7 +770,6 @@ void linenoiseEditHistoryNext(struct linenoiseState *l, int dir) {
     if (searchmode) {
         linenoiseStopReverseSearch(l);
     }
-
     if (history_len > 1) {
         /*
          * Find item in history that matches string

--- a/linenoise.c
+++ b/linenoise.c
@@ -205,16 +205,16 @@ FILE *lndebug_fp = NULL;
 #define lndebug(fmt, ...)
 #endif
 
-/* Debugging macro. */
+/* Debugging macro: log arguments to file. */
 #if 1
-FILE *lndebug_fp = NULL;
+FILE *debug_fp = NULL;
 #define debug(...) \
     do { \
-        if (lndebug_fp == NULL) { \
-            lndebug_fp = fopen("/tmp/lndebug.txt","a"); \
+        if (debug_fp == NULL) { \
+            debug_fp = fopen("/tmp/debug.txt","a"); \
         } \
-        fprintf(lndebug_fp, ", " __VA_ARGS__); \
-        fflush(lndebug_fp); \
+        fprintf(debug_fp, __VA_ARGS__); \
+        fflush(debug_fp); \
     } while (0)
 #else
 #define lndebug(fmt, ...)
@@ -789,13 +789,6 @@ void linenoiseEditHistoryNext(struct linenoiseState *l, int dir) {
         linenoiseStopReverseSearch(l);
     }
     if (history_len > 1) {
-        /*
-         * Find item in history that matches string
-         * Instead of breaking at the found item, find the next item and return that instead
-         * No..
-         * Like with history next item, we need to keep track...
-         */
-
         /* Update the current history entry before to
          * overwrite it with the next one. */
         free(history[history_len - 1 - l->history_index]);
@@ -1124,7 +1117,6 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
             }
             break;
         default:
-            debug("regular %c %d", c, searchmode);
             if (searchmode) {
                 linenoiseSearchModeEditInsert(&l,c);
             } else {
@@ -1158,7 +1150,6 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
             refreshLine(&l);
             break;
         case CTRL_W: /* ctrl+w, delete previous word */
-            debug("del word %c", c);
             linenoiseEditDeletePrevWord(&l);
             break;
         }

--- a/linenoise.h
+++ b/linenoise.h
@@ -48,6 +48,14 @@ typedef struct linenoiseCompletions {
   char **cvec;
 } linenoiseCompletions;
 
+
+typedef struct searchState {
+    int index;  /* Index of history item currently selected in search. */
+    int failed; /* On when nothing in the history matches. */
+    char *query;      /* History search input. */
+} searchState;
+
+
 typedef void(linenoiseCompletionCallback)(const char *, linenoiseCompletions *);
 typedef char*(linenoiseHintsCallback)(const char *, int *color, int *bold);
 typedef void(linenoiseFreeHintsCallback)(void *);

--- a/linenoise.h
+++ b/linenoise.h
@@ -50,9 +50,11 @@ typedef struct linenoiseCompletions {
 
 
 typedef struct searchState {
-    int index;  /* Index of history item currently selected in search. */
-    int failed; /* On when nothing in the history matches. */
-    char *query;      /* History search input. */
+    int index;     /* Index of history item currently selected in search. */
+    int failed;    /* On when nothing in the history matches the search buffer. */
+    size_t len;    /* Length of the currently edited search line. */
+    size_t buflen; /* Length of the history search buffer. */
+    char *buf;     /* History search buffer. */
 } searchState;
 
 


### PR DESCRIPTION
This is a proof of concept for reverse history search.

**Bloat?**
As a regular user of redis-cli, I'm constantly running and rerunning commands. Dozens of times every day, I wish I could just Ctrl-r to search for a past command. History search feels like a requirement of any command interface in 2020.

**Design**
* This code introduces a buffer for search queries that works similarly to the edited line buffer, and is the same length as that buffer. When "search mode" is active, the user edits the search buffer, and linenoise searches the history as the user types.
* Rather than crowd the linenoiseState struct with more fields, I've added a struct for search-related state.
* As a POC and to remain simple, the search uses a naive prefix match base on string comparison.

**Behavior**
* Ctrl-r starts history search mode. This mode is active until the user presses Enter, Ctrl-g, arrow keys, Ctrl-w, Ctrl-p, Ctrl-n, Ctrl-u, Ctrl-k.
* While in history search mode, any characters the user types go into the search buffer. Typing a character searches the history, starting from the most recent item, until a match is found.
* As the user types into the search buffer, the characters they type appear in the prompt on screen.
* If a match is found, the history item also displays in the search buffer.
* If no match is found, the prompt changes to show that the search failed.
* If a match is found, the user can press Ctrl-r again to navigate to the next match found in the history.
* If a match is found, pressing Enter will copy the history item into the line buffer.
* **Not supported**: Forward search, full-text search / tokenization / etc.

**Gotchas**
1. I haven't written C in a long, long time, and I wasn't never any good. So while I checked this with valgrind and fixed my mistakes, the result still may not follow correct C conventions. I'm happy to make any corrections with feedback in this area.
2. When normal line editing exceeds the terminal width, linenoise shifts the visible portion of the buffer, but I haven't done that for the search buffer. The result is a sort of ugly line duplication on screen as the user types past the terminal width.