### PR TITLE
Avoid TOCTOU in linenoiseHistorySave

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -1194,7 +1194,7 @@ int linenoiseHistorySave(const char *filename) {
     fp = fopen(filename,"w");
     umask(old_umask);
     if (fp == NULL) return -1;
-    chmod(filename,S_IRUSR|S_IWUSR);
+    fchmod(fp,S_IRUSR|S_IWUSR);
     for (j = 0; j < history_len; j++)
         fprintf(fp,"%s\n",history[j]);
     fclose(fp);


### PR DESCRIPTION
Before this commit the `linenoiseHistorySave` performed `fopen(filename, ...)` and `chmod(filename, ...)` and this creates a time of use vs time of check vulnerability.

I have not checked whether this can be exploited, but the fix is trivial here: we can just use `fchmod` with the opened file descriptor and this is what this commit changes :).

Btw this was found with https://codeql.github.com/ and its https://codeql.github.com/codeql-query-help/cpp/cpp-toctou-race-condition/ rule when scanning a bigger project that used linenoise as a dependency.