### PR TITLE
Change language in README.markdown to be gender neutral

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -147,7 +147,7 @@ You can enable and disable mask mode using the following two functions:
 ## Completion
 
 Linenoise supports completion, which is the ability to complete the user
-input when she or he presses the `<TAB>` key.
+input when they press the `<TAB>` key.
 
 In order to use completion, you need to register a completion callback, which
 is called every time the user presses `<TAB>`. Your callback will return a


### PR DESCRIPTION
Currently, README.markdown usessays "she or he", however this is exclusionary towards nonbinary people. I changed it to say "they", which is commonly used to reference people who's gender is unknown. [Merriaam-Webster dictionary respects this usage as well](https://www.merriam-webster.com/dictionary/they).