### PR TITLE
Free history also in non-raw mode

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -1256,6 +1256,11 @@ int linenoiseHistoryAdd(const char *line) {
         history = malloc(sizeof(char*)*history_max_len);
         if (history == NULL) return 0;
         memset(history,0,(sizeof(char*)*history_max_len));
+
+	if (!atexit_registered) {
+		atexit(linenoiseAtExit);
+		atexit_registered = 1;
+	    }
     }
 
     /* Don't add duplicated lines. */


### PR DESCRIPTION
Avoid valgrind complaints after exiting from a linenoise session in non-raw mode.