### PR TITLE
Don’t check for NULL before calling free()

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -339,8 +339,7 @@ static void freeCompletions(linenoiseCompletions *lc) {
     size_t i;
     for (i = 0; i < lc->len; i++)
         free(lc->cvec[i]);
-    if (lc->cvec != NULL)
-        free(lc->cvec);
+    free(lc->cvec);
 }
 
 /* Called by completeLine() and linenoiseShow() to render the current
@@ -1160,7 +1159,7 @@ static char *linenoiseNoTTY(void) {
             char *oldval = line;
             line = realloc(line,maxlen);
             if (line == NULL) {
-                if (oldval) free(oldval);
+                free(oldval);
                 return NULL;
             }
         }


### PR DESCRIPTION
As per `man 3 free`:

> The free() function deallocates the memory allocation pointed to by ptr. **If ptr is a NULL pointer, no operation is performed.**