### PR TITLE
advance enableRawMode() before getColumns()

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -880,6 +880,10 @@ int linenoiseEditStart(struct linenoiseState *l, int stdin_fd, int stdout_fd, ch
     l->plen = strlen(prompt);
     l->oldpos = l->pos = 0;
     l->len = 0;
+
+    /* Enter raw mode. */
+    if (enableRawMode(l->ifd) == -1) return -1;
+
     l->cols = getColumns(stdin_fd, stdout_fd);
     l->oldrows = 0;
     l->history_index = 0;
@@ -892,9 +896,6 @@ int linenoiseEditStart(struct linenoiseState *l, int stdin_fd, int stdout_fd, ch
      * will actually just read a line from standard input in blocking
      * mode later, in linenoiseEditFeed(). */
     if (!isatty(l->ifd)) return 0;
-
-    /* Enter raw mode. */
-    if (enableRawMode(l->ifd) == -1) return -1;
 
     /* The latest history entry is always our current buffer, that
      * initially is just an empty string. */


### PR DESCRIPTION
In some cases, the ioctl in getColumns() will error out and call getCursorPosition(), and the "\x1b[6n]" control character in this function will cause the output to be displayed back to the terminal. Advancing enableRawMode() to before getColumns() prevents this problem.
![2024-02-23_155336](https://github.com/antirez/linenoise/assets/18673914/41de2a0c-ba37-44c3-8a25-410a611876df)
