### PR TITLE
Add linenoiseWasInterrupted symbol

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -159,6 +159,7 @@ enum KEY_ACTION{
 };
 
 static void linenoiseAtExit(void);
+int linenoiseWasInterrupted = 0;
 int linenoiseHistoryAdd(const char *line);
 #define REFRESH_CLEAN (1<<0)    // Clean the old prompt from the screen
 #define REFRESH_WRITE (1<<1)    // Rewrite the prompt on the screen.
@@ -964,6 +965,7 @@ char *linenoiseEditFeed(struct linenoiseState *l) {
         return strdup(l->buf);
     case CTRL_C:     /* ctrl-c */
         errno = EAGAIN;
+        linenoiseWasInterrupted = 1;
         return NULL;
     case BACKSPACE:   /* backspace */
     case 8:     /* ctrl-h */

--- a/linenoise.h
+++ b/linenoise.h
@@ -45,6 +45,7 @@ extern "C" {
 
 #include <stddef.h> /* For size_t. */
 
+extern int linenoiseWasInterrupted; /* nonzero if last keystroke was ctrl-c */
 extern char *linenoiseEditMore;
 
 /* The linenoiseState structure represents the state during line editing.


### PR DESCRIPTION
Used to let other programs know whether linenoise is interrupted

backport from https://github.com/ocaml-community/ocaml-linenoise/commit/06cd3f37733ba4fef2321b062dd5dc412b1b8640