### PR TITLE
Fix discarded-qualifiers Warning.

### DIFF
--- a/linenoise.h
+++ b/linenoise.h
@@ -45,7 +45,7 @@ extern "C" {
 
 #include <stddef.h> /* For size_t. */
 
-extern char *linenoiseEditMore;
+extern const char *linenoiseEditMore;
 
 /* The linenoiseState structure represents the state during line editing.
  * We pass this state to functions implementing specific editing


### PR DESCRIPTION
- unsupporeted_term should be const char*
- linenoiseEditMore should be const char*, but linenoiseEditFeed() return char *, so add a local heap-allocate variable.


**Warning:**
```
../thirdparty/linenoise/linenoise.c:122:36: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  122 | static char *unsupported_term[] = {"dumb","cons25","emacs",NULL};
      |                                    ^~~~~~
../thirdparty/linenoise/linenoise.c:122:43: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  122 | static char *unsupported_term[] = {"dumb","cons25","emacs",NULL};
      |                                           ^~~~~~~~
../thirdparty/linenoise/linenoise.c:122:52: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  122 |  char *unsupported_term[] = {"dumb","cons25","emacs",NULL};
      |                                              ^~~~~~~

../thirdparty/linenoise/linenoise.c:908:27: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  908 | char *linenoiseEditMore = "If you see this, you are misusing the API: when linenoiseEditFeed() is called, if it returns linenoiseEditMore the user is yet editing the line. See the README file for more information.";
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```