### PR TITLE
Fix 'comparison is always false' warning on ARM/unsigned char platforms

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -943,7 +943,7 @@ char *linenoiseEditFeed(struct linenoiseState *l) {
     if ((l->in_completion || c == 9) && completionCallback != NULL) {
         c = completeLine(l,c);
         /* Return on errors */
-        if (c < 0) return NULL;
+        if ((signed char)c < 0) return NULL;
         /* Read next character when 0 */
         if (c == 0) return linenoiseEditMore;
     }


### PR DESCRIPTION
### Title
Fix type limit warning in linenoiseEditFeed on ARM builds

### Description
I encountered a compilation warning when cross-compiling for AArch64 (ARMv8) using GCC with `-Wextra` enabled:

> warning: comparison is always false due to limited range of data type [-Wtype-limits]
> if (c < 0) return NULL;

**Reason:**
On ARM platforms, the `char` type is `unsigned` by default (0 to 255). Therefore, the check `c < 0` never evaluates to true, effectively ignoring error codes returned by `completeLine()`.

**Fix:**
Explicitly cast `c` to `(signed char)` in the conditional check. This ensures that negative return values are correctly identified regardless of the platform's default `char` signedness.

### Verification
- Verified that the warning disappears after the fix on AArch64 cross-compilation.
- Verified that the code still compiles correctly on x86 environments.