### PR TITLE
Some very minor tweaks form usage

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -118,8 +118,6 @@
 #include <stdint.h>
 #include "linenoise.h"
 
-#define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
-#define LINENOISE_MAX_LINE 4096
 static char *unsupported_term[] = {"dumb","cons25","emacs",NULL};
 static linenoiseCompletionCallback *completionCallback = NULL;
 static linenoiseHintsCallback *hintsCallback = NULL;

--- a/linenoise.c
+++ b/linenoise.c
@@ -1549,7 +1549,7 @@ void linenoisePrintKeyCodes(void) {
         if (memcmp(quit,"quit",sizeof(quit)) == 0) break;
 
         printf("'%c' %02x (%d) (type quit to exit)\n",
-            isprint(c) ? c : '?', (int)c, (int)c);
+            isprint(c) ? c : '?', (unsigned int)c, (int)c);
         printf("\r"); /* Go left edge manually, we are in raw mode. */
         fflush(stdout);
     }

--- a/linenoise.h
+++ b/linenoise.h
@@ -39,6 +39,14 @@
 #ifndef __LINENOISE_H
 #define __LINENOISE_H
 
+#ifndef LINENOISE_DEFAULT_HISTORY_MAX_LEN
+#define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
+#endif
+
+#ifndef LINENOISE_MAX_LINE
+#define LINENOISE_MAX_LINE 4096
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/linenoise.h
+++ b/linenoise.h
@@ -36,8 +36,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __LINENOISE_H
-#define __LINENOISE_H
+#ifndef LINENOISE_H
+#define LINENOISE_H
 
 #ifndef LINENOISE_DEFAULT_HISTORY_MAX_LEN
 #define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
@@ -119,4 +119,4 @@ void linenoiseMaskModeDisable(void);
 }
 #endif
 
-#endif /* __LINENOISE_H */
+#endif /* LINENOISE_H */


### PR DESCRIPTION
- Move `LINENOISE_DEFAULT_HISTORY_MAX_LEN` and `LINENOISE_MAX_LINE` macro definitions to the header so they are available for users to reference.  Also wrap them in `ifndef` so users can override them using compiler directives.
- Adjust include guard macros to comply with standards on reserved symbols.
- Fix a sign issue with a format string argument that causes an error with very pedantic compiler settings.