### PR TITLE
fix 248 with a minimal impact

### DIFF
--- a/linenoise.c
+++ b/linenoise.c
@@ -447,7 +447,7 @@ static int utf8SingleCharWidth(const char *s, size_t len) {
 }
 
 enum KEY_ACTION{
-	KEY_NULL = 0,	    /* NULL */
+	KEY_NULL = 0,       /* NULL */
 	CTRL_A = 1,         /* Ctrl+a */
 	CTRL_B = 2,         /* Ctrl-b */
 	CTRL_C = 3,         /* Ctrl-c */
@@ -736,11 +736,10 @@ static int completeLine(struct linenoiseState *ls, int keypressed) {
                 }
                 c = 0;
                 break;
-            case 27: /* escape */
-                /* Re-show original buffer */
+            case 27: /* escape or escape sequence */
+                /* Re-show original buffer, i.e. exit completion loop */
                 if (ls->completion_idx < lc.len) refreshLine(ls);
                 ls->in_completion = 0;
-                c = 0;
                 break;
             default:
                 /* Update buffer and return */
@@ -1319,7 +1318,7 @@ char *linenoiseEditFeed(struct linenoiseState *l) {
      * count limits. */
     if (!isatty(l->ifd) && !getenv("LINENOISE_ASSUME_TTY")) return linenoiseNoTTY();
 
-    char c;
+    char c, pc;
     int nread;
     char seq[3];
 
@@ -1339,6 +1338,9 @@ char *linenoiseEditFeed(struct linenoiseState *l) {
         if (retval == 0) return linenoiseEditMore;
         c = retval;
     }
+
+pending:
+    pc = 0;
 
     switch(c) {
     case ENTER:    /* enter */
@@ -1399,11 +1401,20 @@ char *linenoiseEditFeed(struct linenoiseState *l) {
     case CTRL_N:    /* ctrl-n */
         linenoiseEditHistoryNext(l, LINENOISE_HISTORY_NEXT);
         break;
-    case ESC:    /* escape sequence */
+    case ESC:    /* escape or escape sequence */
         /* Read the next two bytes representing the escape sequence.
          * Use two calls to handle slow terminals returning the two
-         * chars at different times. */
+         * chars at different times.
+         * NOTE: if the completeLine has returned an ESC to be handled
+         * we cannot assume that we have to deal with an escape sequence,
+         * the user might have pressed the ESC just to leave the
+         * completion loop, in that case care must be taken to avoid
+         * consuming valid user input. */
         if (read(l->ifd,seq,1) == -1) break;
+        if (seq[0] != '[' && seq[0] == 'O') {
+            pc = seq[0];
+            break;
+        }
         if (read(l->ifd,seq+1,1) == -1) break;
 
         /* ESC [ sequences. */
@@ -1495,6 +1506,10 @@ char *linenoiseEditFeed(struct linenoiseState *l) {
     case CTRL_W: /* ctrl+w, delete previous word */
         linenoiseEditDeletePrevWord(l);
         break;
+    }
+    if (pc) {
+        c = pc;
+        goto pending;
     }
     return linenoiseEditMore;
 }

--- a/linenoise.c
+++ b/linenoise.c
@@ -1402,16 +1402,18 @@ pending:
         linenoiseEditHistoryNext(l, LINENOISE_HISTORY_NEXT);
         break;
     case ESC:    /* escape or escape sequence */
-        /* Read the next two bytes representing the escape sequence.
+        /* We cannot distinguish an ESC key press from  other keys
+         * presses that generate escape sequences.
+         * This could be the start of an escape sequence or the user
+         * might have pressed the ESC just to leave the completion loop,
+         * in the last case care must be taken to avoid consuming input.
+         * Read the next two bytes representing the escape sequence.
          * Use two calls to handle slow terminals returning the two
-         * chars at different times.
-         * NOTE: if the completeLine has returned an ESC to be handled
-         * we cannot assume that we have to deal with an escape sequence,
-         * the user might have pressed the ESC just to leave the
-         * completion loop, in that case care must be taken to avoid
-         * consuming valid user input. */
+         * chars at different times. */
         if (read(l->ifd,seq,1) == -1) break;
         if (seq[0] != '[' && seq[0] != 'O') {
+            /* Not a known sequence. Assume ESC was already used (e.g.
+             * by completeLine) and set the pending char to reparse. */
             pc = seq[0];
             break;
         }

--- a/linenoise.c
+++ b/linenoise.c
@@ -1411,7 +1411,7 @@ pending:
          * completion loop, in that case care must be taken to avoid
          * consuming valid user input. */
         if (read(l->ifd,seq,1) == -1) break;
-        if (seq[0] != '[' && seq[0] == 'O') {
+        if (seq[0] != '[' && seq[0] != 'O') {
             pc = seq[0];
             break;
         }


### PR DESCRIPTION
I believe it is impossible to implement a completion loop without running into the problem described in #248.

But perhaps no one has noticed another problem related to the management of the ESC key which in my opinion is strictly linked to the #248 (well described in #129 about a decade ago.) That is, after you press the ESC key, linenoise **throws away the next two characters** you press.

These problems arises because linenoise cannot distinguish (and does not even try to distinguish) the ESC key press from other keys that produce an escape sequence.

I saw the solution proposed in #230 but I don't like the fact that any character other than a TAB overwrites the buffer, as if the only way to escape a completion loop was to accept the current completion.

I think it's fair to be able to abort the loop and return to the previous buffer by simply pressing ESC. But I'm sure we all hit the arrow keys while iterating with TAB.

So in my opinion the simplest solution is through:
1. let the `completeLine` do its job and exit the loop as soon as it sees an ESC, but leave the responsibility of handling it to its caller, which is exactly how it was intended, and
2. In `linenoiseEditFeed`, don't make too many assumptions that an escape key necessarily means an escape sequence, and so be careful not to throw away keys that aren't part of an escape sequence.

It doesn't cover 100% of cases, but it has the minimum impact on the current implementation (only 11 lines of code: 1 deleted + 10 added are actually needed), also thanks to a nice **goto**, which I put in to avoid making dangerous jumps from inside a switch (they've already invented coroutines.)
Of course the goto is a provocation, it could be done with `do ... while`, but the implementation with goto is certainly more readable, as well as being shorter.

I didn't even consider using `ungetc`, especially since to really handle all cases (instead of just one `pc` character) you should use a queue and put in it all the extracted characters that need to be _reconsidered_.

> [!NOTE]
> For those who want to try, here is a version of the file with the changes (to replace the original one)
> [**linenoise_2026-04-12.zip**](https://github.com/user-attachments/files/26883535/linenoise_2026-04-12.zip)
